### PR TITLE
Correction of small syntax error

### DIFF
--- a/xsd/siri_model/siri_situationReasons-v2.0.xsd
+++ b/xsd/siri_model/siri_situationReasons-v2.0.xsd
@@ -1975,10 +1975,11 @@ Rail transport, Roads and road transport
      <xsd:documentation>TPEG Pti22_2 rough sea.</xsd:documentation>
     </xsd:annotation>
    </xsd:enumeration>
-   <xsd:enumeration value="heavySnowFall"/>
-   <xsd:annotation>
-    <xsd:documentation>TPEG Pti22_3 heavy snow fall.</xsd:documentation>
-   </xsd:annotation>
+   <xsd:enumeration value="heavySnowFall">
+    <xsd:annotation>
+     <xsd:documentation>TPEG Pti22_3 heavy snow fall.</xsd:documentation>
+    </xsd:annotation>
+   </xsd:enumeration>
    <xsd:enumeration value="driftingSnow">
     <xsd:annotation>
      <xsd:documentation>drifting snow - Alias to TPEG Pti22_3 heavySnowFall.</xsd:documentation>


### PR DESCRIPTION
Bug was found by Travis CI and must be fixed for the xsd to be a valid xml file (syntax error). xmllint throws the following error:
xsd/siri_model/siri_situationReasons-v2.0.xsd:1979: element annotation: Schemas parser error : Element '{http://www.w3.org/2001/XMLSchema}restriction': The content is not valid. Expected is (annotation?, (simpleType?, (minExclusive | minInclusive | maxExclusive | maxInclusive | totalDigits | fractionDigits | length | minLength | maxLength | enumeration | whiteSpace | pattern)*)).