### PR TITLE
CR024: add aimed times to interchange feed./distr.

### DIFF
--- a/xsd/siri_model/siri_datedVehicleJourney-v2.0.xsd
+++ b/xsd/siri_model/siri_datedVehicleJourney-v2.0.xsd
@@ -237,6 +237,16 @@ Rail transport, Roads and road transport
      <xsd:documentation>Sequence of visit to Feeder stop within Feeder JOURNEY PATTERN.</xsd:documentation>
     </xsd:annotation>
    </xsd:element>
+   <xsd:element name="FeederStopOrder" type="xsd:positiveInteger" minOccurs="0">
+    <xsd:annotation>
+     <xsd:documentation>For implementations in which the overall order is not defined by VISIT NUMBER, i.e. in case VisitNumberIsOrder is set to false, ORDER can be used to associate the stop order instead. ORDER is also used together with VISIT NUMBER in scenarios where an extra CALL is inserted as a result of despatching alterations. Because such an extra CALL may have the same VisitNumber as another (cancelled) CALL, the STOP ORDER is needed. +SIRI v2.1</xsd:documentation>
+    </xsd:annotation>
+   </xsd:element>
+   <xsd:element name="AimedArrivalTimeOfFeeder" type="xsd:dateTime" minOccurs="0">
+    <xsd:annotation>
+     <xsd:documentation>Planned time at which feeder VEHICLE is scheduled to arrive. SIRI v2.1</xsd:documentation>
+    </xsd:annotation>
+   </xsd:element>
    <xsd:element name="DistributorRef" type="ConnectingJourneyRefStructure" minOccurs="0">
     <xsd:annotation>
      <xsd:documentation>Reference to a feeder VEHICLE JOURNEY. +SIRI v2.0</xsd:documentation>
@@ -250,6 +260,16 @@ Rail transport, Roads and road transport
    <xsd:element name="DistributorVisitNumber" type="VisitNumberType" minOccurs="0">
     <xsd:annotation>
      <xsd:documentation>Sequence of visit to Distributor stop within Distributor JOURNEY PATTERN.</xsd:documentation>
+    </xsd:annotation>
+   </xsd:element>
+   <xsd:element name="DistributorStopOrder" type="xsd:positiveInteger" minOccurs="0">
+    <xsd:annotation>
+     <xsd:documentation>For implementations in which the overall order is not defined by VISIT NUMBER, i.e. in case VisitNumberIsOrder is set to false, ORDER can be used to associate the stop order instead. ORDER is also used together with VISIT NUMBER in scenarios where an extra CALL is inserted as a result of despatching alterations. Because such an extra CALL may have the same VisitNumber as another (cancelled) CALL, the STOP ORDER is needed. +SIRI v2.1</xsd:documentation>
+    </xsd:annotation>
+   </xsd:element>
+   <xsd:element name="AimedDepartureTimeOfDistributor" type="xsd:dateTime" minOccurs="0">
+    <xsd:annotation>
+     <xsd:documentation>Planned time at which distributor VEHICLE is scheduled to depart. SIRI v2.1</xsd:documentation>
     </xsd:annotation>
    </xsd:element>
    <xsd:group ref="InterchangePropertyGroup"/>
@@ -290,6 +310,16 @@ Rail transport, Roads and road transport
        <xsd:documentation>Sequence of visit to Feeder stop within Feeder JOURNEY PATTERN.</xsd:documentation>
       </xsd:annotation>
      </xsd:element>
+     <xsd:element name="FeederStopOrder" type="xsd:positiveInteger" minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>For implementations in which the overall order is not defined by VISIT NUMBER, i.e. in case VisitNumberIsOrder is set to false, ORDER can be used to associate the stop order instead. ORDER is also used together with VISIT NUMBER in scenarios where an extra CALL is inserted as a result of despatching alterations. Because such an extra CALL may have the same VisitNumber as another (cancelled) CALL, the STOP ORDER is needed. +SIRI v2.1</xsd:documentation>
+      </xsd:annotation>
+     </xsd:element>
+     <xsd:element name="AimedArrivalTimeOfFeeder" type="xsd:dateTime" minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>Planned time at which feeder VEHICLE is scheduled to arrive. SIRI v2.1</xsd:documentation>
+      </xsd:annotation>
+     </xsd:element>
      <xsd:element name="DistributorRef" type="ConnectingJourneyRefStructure" minOccurs="0" maxOccurs="0">
       <xsd:annotation>
        <xsd:documentation>Reference to a feeder VEHICLE JOURNEY. +SIRI v2.0</xsd:documentation>
@@ -303,6 +333,16 @@ Rail transport, Roads and road transport
      <xsd:element name="DistributorVisitNumber" type="VisitNumberType" minOccurs="0" maxOccurs="0">
       <xsd:annotation>
        <xsd:documentation>Sequence of visit to Distributor stop within Distributor JOURNEY PATTERN.</xsd:documentation>
+      </xsd:annotation>
+     </xsd:element>
+     <xsd:element name="DistributorStopOrder" type="xsd:positiveInteger" minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>For implementations in which the overall order is not defined by VISIT NUMBER, i.e. in case VisitNumberIsOrder is set to false, ORDER can be used to associate the stop order instead. ORDER is also used together with VISIT NUMBER in scenarios where an extra CALL is inserted as a result of despatching alterations. Because such an extra CALL may have the same VisitNumber as another (cancelled) CALL, the STOP ORDER is needed. +SIRI v2.1</xsd:documentation>
+      </xsd:annotation>
+     </xsd:element>
+     <xsd:element name="AimedDepartureTimeOfDistributor" type="xsd:dateTime" minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>Planned time at which distributor VEHICLE is scheduled to depart. SIRI v2.1</xsd:documentation>
       </xsd:annotation>
      </xsd:element>
      <xsd:group ref="InterchangePropertyGroup"/>
@@ -345,6 +385,16 @@ Rail transport, Roads and road transport
        <xsd:documentation>Sequence of visit to Feeder stop within Feeder JOURNEY PATTERN.</xsd:documentation>
       </xsd:annotation>
      </xsd:element>
+     <xsd:element name="FeederStopOrder" type="xsd:positiveInteger" minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>For implementations in which the overall order is not defined by VISIT NUMBER, i.e. in case VisitNumberIsOrder is set to false, ORDER can be used to associate the stop order instead. ORDER is also used together with VISIT NUMBER in scenarios where an extra CALL is inserted as a result of despatching alterations. Because such an extra CALL may have the same VisitNumber as another (cancelled) CALL, the STOP ORDER is needed. +SIRI v2.1</xsd:documentation>
+      </xsd:annotation>
+     </xsd:element>
+     <xsd:element name="AimedArrivalTimeOfFeeder" type="xsd:dateTime" minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>Planned time at which feeder VEHICLE is scheduled to arrive. SIRI v2.1</xsd:documentation>
+      </xsd:annotation>
+     </xsd:element>
      <xsd:element name="DistributorRef" type="ConnectingJourneyRefStructure">
       <xsd:annotation>
        <xsd:documentation>Reference to a feeder VEHICLE JOURNEY. +SIRI v2.0</xsd:documentation>
@@ -358,6 +408,16 @@ Rail transport, Roads and road transport
      <xsd:element name="DistributorVisitNumber" type="VisitNumberType" minOccurs="0">
       <xsd:annotation>
        <xsd:documentation>Sequence of visit to Distributor stop within Distributor JOURNEY PATTERN.</xsd:documentation>
+      </xsd:annotation>
+     </xsd:element>
+     <xsd:element name="DistributorStopOrder" type="xsd:positiveInteger" minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>For implementations in which the overall order is not defined by VISIT NUMBER, i.e. in case VisitNumberIsOrder is set to false, ORDER can be used to associate the stop order instead. ORDER is also used together with VISIT NUMBER in scenarios where an extra CALL is inserted as a result of despatching alterations. Because such an extra CALL may have the same VisitNumber as another (cancelled) CALL, the STOP ORDER is needed. +SIRI v2.1</xsd:documentation>
+      </xsd:annotation>
+     </xsd:element>
+     <xsd:element name="AimedDepartureTimeOfDistributor" type="xsd:dateTime" minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>Planned time at which distributor VEHICLE is scheduled to depart. SIRI v2.1</xsd:documentation>
       </xsd:annotation>
      </xsd:element>
      <xsd:group ref="InterchangePropertyGroup"/>
@@ -400,6 +460,16 @@ Rail transport, Roads and road transport
        <xsd:documentation>Sequence of visit to Feeder stop within Feeder JOURNEY PATTERN.</xsd:documentation>
       </xsd:annotation>
      </xsd:element>
+     <xsd:element name="FeederStopOrder" type="xsd:positiveInteger" minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>For implementations in which the overall order is not defined by VISIT NUMBER, i.e. in case VisitNumberIsOrder is set to false, ORDER can be used to associate the stop order instead. ORDER is also used together with VISIT NUMBER in scenarios where an extra CALL is inserted as a result of despatching alterations. Because such an extra CALL may have the same VisitNumber as another (cancelled) CALL, the STOP ORDER is needed. +SIRI v2.1</xsd:documentation>
+      </xsd:annotation>
+     </xsd:element>
+     <xsd:element name="AimedArrivalTimeOfFeeder" type="xsd:dateTime" minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>Planned time at which feeder VEHICLE is scheduled to arrive. SIRI v2.1</xsd:documentation>
+      </xsd:annotation>
+     </xsd:element>
      <xsd:element name="DistributorRef" type="ConnectingJourneyRefStructure">
       <xsd:annotation>
        <xsd:documentation>Reference to a feeder VEHICLE JOURNEY. +SIRI v2.0</xsd:documentation>
@@ -413,6 +483,16 @@ Rail transport, Roads and road transport
      <xsd:element name="DistributorVisitNumber" type="VisitNumberType" minOccurs="0">
       <xsd:annotation>
        <xsd:documentation>Sequence of visit to Distributor stop within Distributor JOURNEY PATTERN.</xsd:documentation>
+      </xsd:annotation>
+     </xsd:element>
+     <xsd:element name="DistributorStopOrder" type="xsd:positiveInteger" minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>For implementations in which the overall order is not defined by VISIT NUMBER, i.e. in case VisitNumberIsOrder is set to false, ORDER can be used to associate the stop order instead. ORDER is also used together with VISIT NUMBER in scenarios where an extra CALL is inserted as a result of despatching alterations. Because such an extra CALL may have the same VisitNumber as another (cancelled) CALL, the STOP ORDER is needed. +SIRI v2.1</xsd:documentation>
+      </xsd:annotation>
+     </xsd:element>
+     <xsd:element name="AimedDepartureTimeOfDistributor" type="xsd:dateTime" minOccurs="0">
+      <xsd:annotation>
+       <xsd:documentation>Planned time at which distributor VEHICLE is scheduled to depart. SIRI v2.1</xsd:documentation>
       </xsd:annotation>
      </xsd:element>
      <xsd:group ref="InterchangePropertyGroup"/>


### PR DESCRIPTION
Consequence of Change Request 022. To harmonize between the extended ET interchange and PT, two elements for the aimed arrival/departure times must be added to the dated interchange structures. Commits for CR028 are already integrated.