### PR TITLE
CR001: add new element PredictionInaccurateReason

### DIFF
--- a/xsd/siri_model/siri_estimatedVehicleJourney-v2.0.xsd
+++ b/xsd/siri_model/siri_estimatedVehicleJourney-v2.0.xsd
@@ -165,6 +165,11 @@ DEPRECATED from SRI 2.0</xsd:documentation>
      <xsd:documentation>Whether the prediction for the journey is considered to be of a useful accuracy or not. Default is 'false'.</xsd:documentation>
     </xsd:annotation>
    </xsd:element>
+   <xsd:element name="PredictionInaccurateReason" type="PredictionInaccurateReasonEnumeration" minOccurs="0">
+    <xsd:annotation>
+     <xsd:documentation>Can be used to inform the passenger about the reason for a change of the prediction (in)accuracy in case PredictionInaccurate is set to 'true'. +SIRI v2.1</xsd:documentation>
+    </xsd:annotation>
+   </xsd:element>
    <xsd:element name="Occupancy" type="OccupancyEnumeration" minOccurs="0">
     <xsd:annotation>
      <xsd:documentation>How full the bus is. If omitted: Passenger load is unknown.</xsd:documentation>
@@ -362,6 +367,11 @@ the original journey and the nature of the difference.</xsd:documentation>
    <xsd:element name="PredictionInaccurate" type="xsd:boolean" minOccurs="0">
     <xsd:annotation>
      <xsd:documentation>Whether the prediction for the specific stop is considered to be of a useful accuracy or not. Default is 'false', i.e. prediction is not known to be inaccurate. {DOUBLE NEGATIVE IS BAD _ BETTER AS PredictionAccurate. Default is 'true'?]. If prediction is degraded, e.g. because in congestion, used to 9indicate a lowered quality of data. Inherited property. {SHOULD THIS JUST BE THE SPECIFIC InCongestion INDICATOR INSTEAD, OR IS IT MORE GENERAL]</xsd:documentation>
+    </xsd:annotation>
+   </xsd:element>
+   <xsd:element name="PredictionInaccurateReason" type="PredictionInaccurateReasonEnumeration" minOccurs="0">
+    <xsd:annotation>
+     <xsd:documentation>Can be used to inform the passenger about the reason for a change of the prediction (in)accuracy in case PredictionInaccurate is set to 'true'. +SIRI v2.1</xsd:documentation>
     </xsd:annotation>
    </xsd:element>
    <xsd:element name="Occupancy" type="OccupancyEnumeration" minOccurs="0">

--- a/xsd/siri_model/siri_journey_support-v2.0.xsd
+++ b/xsd/siri_model/siri_journey_support-v2.0.xsd
@@ -573,4 +573,37 @@ Corresponds to NeTEX TYPE OF SERVICe.</xsd:documentation>
    <xsd:enumeration value="unspecified"/>
   </xsd:restriction>
  </xsd:simpleType>
+ <!-- =====PredictionInaccuracy============================================================ -->
+ <xsd:simpleType name="PredictionInaccurateReasonEnumeration">
+  <xsd:annotation>
+   <xsd:documentation>Allowed values for PredictionInaccurateReason, i.e., possible reasons for a change in prediction (in)accuracy.</xsd:documentation>
+  </xsd:annotation>
+  <xsd:restriction base="xsd:NMTOKEN">
+   <xsd:enumeration value="vehicleInTrafficJam">
+    <xsd:annotation>
+     <xsd:documentation>Prediction is inaccurate because of a traffic jam.</xsd:documentation>
+    </xsd:annotation>
+   </xsd:enumeration>
+   <xsd:enumeration value="technicalProblem">
+    <xsd:annotation>
+     <xsd:documentation>Prediction is inaccurate because of technical problems.</xsd:documentation>
+    </xsd:annotation>
+   </xsd:enumeration>
+   <xsd:enumeration value="dispatchAction">
+    <xsd:annotation>
+     <xsd:documentation>Prediction is inaccurate because of a despatching alteration.</xsd:documentation>
+    </xsd:annotation>
+   </xsd:enumeration>
+   <xsd:enumeration value="missingUpdate">
+    <xsd:annotation>
+     <xsd:documentation>Prediction is inaccurate because communication errors have prevented any updates.</xsd:documentation>
+    </xsd:annotation>
+   </xsd:enumeration>
+   <xsd:enumeration value="unknown">
+    <xsd:annotation>
+     <xsd:documentation>Prediction is inaccurate but the reason for an inaccurate prediction is unknown.</xsd:documentation>
+    </xsd:annotation>
+   </xsd:enumeration>
+  </xsd:restriction>
+ </xsd:simpleType>
 </xsd:schema>

--- a/xsd/siri_model/siri_monitoredVehicleJourney-v2.0.xsd
+++ b/xsd/siri_model/siri_monitoredVehicleJourney-v2.0.xsd
@@ -158,6 +158,11 @@ Rail transport, Roads and road transport
      <xsd:documentation>Whether the prediction should be judged as inaccurate.</xsd:documentation>
     </xsd:annotation>
    </xsd:element>
+   <xsd:element name="PredictionInaccurateReason" type="PredictionInaccurateReasonEnumeration" minOccurs="0">
+    <xsd:annotation>
+     <xsd:documentation>Can be used to inform the passenger about the reason for a change of the prediction (in)accuracy in case PredictionInaccurate is set to 'true'. +SIRI v2.1</xsd:documentation>
+    </xsd:annotation>
+   </xsd:element>
    <xsd:element name="DataSource" type="xsd:string" minOccurs="0">
     <xsd:annotation>
      <xsd:documentation>System originating real-time data. Can be used to make judgements of relative quality and accuracy compared to other feeds.</xsd:documentation>


### PR DESCRIPTION
Change Request for the addition of a new element PredictionInaccurateReason and a new enumeration. Element is integrated in all structures/groups that include PredictionInaccurate. It should only be transmitted in case PredictionInaccurate is set to 'true'. 
See documentation in the basecamp:
[Siri_CR_001_PredictionInaccurate.doc](https://3.basecamp.com/3256016/buckets/9672657/uploads/1561504844)