### PR TITLE
CR007 / CR031: add new FilterBy and policy parameters to ET and PT

### DIFF
--- a/xsd/siri/siri_request_support-v2.0.xsd
+++ b/xsd/siri/siri_request_support-v2.0.xsd
@@ -143,8 +143,17 @@ Rail transport, Roads and road transport
  <xsd:element name="IncludeTranslations" type="xsd:boolean">
   <xsd:annotation>
    <xsd:documentation>Whether additional translations of text names are to be included in elements. If false, then only one element should be returned.  Default is false.
-
 Where multiple values are returned The first element returned ill be used as the default value.</xsd:documentation>
+  </xsd:annotation>
+ </xsd:element>
+ <xsd:element name="IncludeInterchanges" type="xsd:boolean" default="true">
+  <xsd:annotation>
+   <xsd:documentation>Whether SERVICE JOURNEY INTERCHANGE data is to be transmitted or not. Default is true. +SIRI v2.1</xsd:documentation>
+  </xsd:annotation>
+ </xsd:element>
+ <xsd:element name="IncludeJourneyRelations" type="xsd:boolean" default="true">
+  <xsd:annotation>
+   <xsd:documentation>Whether JOURNEY RELATION data is to be transmitted or not. Default is true. +SIRI v2.1</xsd:documentation>
   </xsd:annotation>
  </xsd:element>
  <!-- ======================================================================= -->

--- a/xsd/siri_estimatedTimetable_service.xsd
+++ b/xsd/siri_estimatedTimetable_service.xsd
@@ -395,6 +395,9 @@ If false each subscription response will contain the full information as specifi
         </xsd:element>
         <xsd:element ref="FilterByOperatorRef"/>
         <xsd:element ref="FilterByLineRef"/>
+		<xsd:element ref="FilterByVehicleMode"/>
+		<xsd:element ref="FilterByProductCategoryRef"/>
+		<xsd:element ref="FilterByStopPointRef"/>
         <xsd:element name="FilterByVersionRef" type="xsd:boolean" default="true" minOccurs="0">
          <xsd:annotation>
           <xsd:documentation>Whether results can be filtered by TIMETABLE VERSION Default is 'true'.</xsd:documentation>

--- a/xsd/siri_estimatedTimetable_service.xsd
+++ b/xsd/siri_estimatedTimetable_service.xsd
@@ -196,6 +196,8 @@ Rail transport, Roads and road transport
     </xsd:annotation>
    </xsd:element>
    <xsd:element ref="IncludeTranslations" minOccurs="0"/>
+   <xsd:element ref="IncludeInterchanges" minOccurs="0"/>
+   <xsd:element ref="IncludeJourneyRelations" minOccurs="0"/>
    <xsd:element name="EstimatedTimetableDetailLevel" type="EstimatedTimetableDetailEnumeration" default="calls" minOccurs="0">
     <xsd:annotation>
      <xsd:documentation>Level of detail to include in response. Default is 'normal'. (SIRI 2.0)</xsd:documentation>

--- a/xsd/siri_estimatedTimetable_service.xsd
+++ b/xsd/siri_estimatedTimetable_service.xsd
@@ -168,6 +168,21 @@ Rail transport, Roads and road transport
      </xsd:sequence>
     </xsd:complexType>
    </xsd:element>
+   <xsd:element name="VehicleMode" type="VehicleModesEnumeration" minOccurs="0" maxOccurs="unbounded">
+    <xsd:annotation>
+     <xsd:documentation>Filter the results to include only journeys of the specified VEHICLE MODE. +SIRI v2.1</xsd:documentation>
+    </xsd:annotation>
+   </xsd:element>
+   <xsd:element name="ProductCategoryRef" type="ProductCategoryRefStructure" minOccurs="0" maxOccurs="unbounded">
+    <xsd:annotation>
+     <xsd:documentation>Filter the results to include only journeys of the specified TYPE OF PRODUCT CATEGORY. +SIRI v2.1</xsd:documentation>
+    </xsd:annotation>
+   </xsd:element>
+   <xsd:element name="StopPointRef" type="StopPointRefStructure" minOccurs="0" maxOccurs="unbounded">
+    <xsd:annotation>
+     <xsd:documentation>Filter the results to include only journeys with a CALL at the specified STOP POINT. +SIRI v2.1</xsd:documentation>
+    </xsd:annotation>
+   </xsd:element>
   </xsd:sequence>
  </xsd:group>
  <xsd:group name="EstimatedTimetableRequestPolicyGroup">

--- a/xsd/siri_model/siri_modelPermissions-v2.0.xsd
+++ b/xsd/siri_model/siri_modelPermissions-v2.0.xsd
@@ -251,6 +251,16 @@ Rail transport, Roads and road transport
    <xsd:documentation>Whether results can be filtered by Facility (EQUIPMENT). Default is 'true'.</xsd:documentation>
   </xsd:annotation>
  </xsd:element>
+ <xsd:element name="FilterByVehicleMode" type="xsd:boolean" default="true">
+  <xsd:annotation>
+   <xsd:documentation>Whether results can be filtered by VEHICLE MODE. Default is 'true'. +SIRI v2.1</xsd:documentation>
+  </xsd:annotation>
+ </xsd:element>
+ <xsd:element name="FilterByProductCategoryRef" type="xsd:boolean" default="true">
+  <xsd:annotation>
+   <xsd:documentation>Whether results can be filtered by PRODUCT CATEGORY. Default is 'true'. +SIRI v2.1</xsd:documentation>
+  </xsd:annotation>
+ </xsd:element>
  <!-- ======================================================================= -->
  <xsd:complexType name="MonitoringCapabilityAccessControlStructure">
   <xsd:annotation>

--- a/xsd/siri_productionTimetable_service.xsd
+++ b/xsd/siri_productionTimetable_service.xsd
@@ -172,6 +172,21 @@ Rail transport, Roads and road transport
      </xsd:sequence>
     </xsd:complexType>
    </xsd:element>
+   <xsd:element name="VehicleMode" type="VehicleModesEnumeration" minOccurs="0" maxOccurs="unbounded">
+    <xsd:annotation>
+     <xsd:documentation>Filter the results to include only journeys of the specified VEHICLE MODE. +SIRI v2.1</xsd:documentation>
+    </xsd:annotation>
+   </xsd:element>
+   <xsd:element name="ProductCategoryRef" type="ProductCategoryRefStructure" minOccurs="0" maxOccurs="unbounded">
+    <xsd:annotation>
+     <xsd:documentation>Filter the results to include only journeys of the specified TYPE OF PRODUCT CATEGORY. +SIRI v2.1</xsd:documentation>
+    </xsd:annotation>
+   </xsd:element>
+   <xsd:element name="StopPointRef" type="StopPointRefStructure" minOccurs="0" maxOccurs="unbounded">
+    <xsd:annotation>
+     <xsd:documentation>Filter the results to include only journeys with a CALL at the specified STOP POINT. +SIRI v2.1</xsd:documentation>
+    </xsd:annotation>
+   </xsd:element>
   </xsd:sequence>
  </xsd:group>
  <xsd:group name="ProductionTimetableRequestPolicyGroup">

--- a/xsd/siri_productionTimetable_service.xsd
+++ b/xsd/siri_productionTimetable_service.xsd
@@ -200,6 +200,8 @@ Rail transport, Roads and road transport
     </xsd:annotation>
    </xsd:element>
    <xsd:element ref="IncludeTranslations" minOccurs="0"/>
+   <xsd:element ref="IncludeInterchanges" minOccurs="0"/>
+   <xsd:element ref="IncludeJourneyRelations" minOccurs="0"/>
    <xsd:element name="IncrementalUpdates" type="xsd:boolean" default="false" minOccurs="0">
     <xsd:annotation>
      <xsd:documentation>Whether to return the whole timetable, or just differences from the inidicated version. Default is 'false'.</xsd:documentation>

--- a/xsd/siri_productionTimetable_service.xsd
+++ b/xsd/siri_productionTimetable_service.xsd
@@ -389,6 +389,9 @@ If false each subscription response will contain the full information as specifi
         <xsd:element ref="FilterByValidityPeriod"/>
         <xsd:element ref="FilterByOperatorRef"/>
         <xsd:element ref="FilterByLineRef"/>
+		<xsd:element ref="FilterByVehicleMode"/>
+		<xsd:element ref="FilterByProductCategoryRef"/>
+		<xsd:element ref="FilterByStopPointRef"/>
         <xsd:element name="FilterByVersionRef" type="xsd:boolean" default="true">
          <xsd:annotation>
           <xsd:documentation>Whether results can be filtered by TIMETABLE VERSION Default is 'true'.</xsd:documentation>


### PR DESCRIPTION
Two new filters FilterByVehicleMode and FilterByProductCategoryRef are added to SIRI, and made available in the PT and ET capabilities. The corresponding topic parameters are added to the PT and ET RequestStructure together with the existing filter capability for StopPointRefs (see also CR031). The PT and ET policy groups are also extendet by two new elements IncludeInterchanges and IncludeJourneyRelations (related to CR005).
See the documentation in the basecamp:
[Siri_CR_007_Extension-of-topics_filter-criteria.doc](https://3.basecamp.com/3256016/buckets/9672657/uploads/1598504348)
[Siri_CR_031_ScheduledStopPoint_Filter.doc](https://3.basecamp.com/3256016/buckets/9672657/uploads/2028724779)