### PR TITLE
CR074: add LatestExpectedArrivalTime to ETCall

### DIFF
--- a/xsd/siri_model/siri_journey-v2.0.xsd
+++ b/xsd/siri_model/siri_journey-v2.0.xsd
@@ -594,9 +594,14 @@ Rail transport, Roads and road transport
   <xsd:sequence>
    <xsd:element ref="AimedArrivalTime" minOccurs="0"/>
    <xsd:element ref="ExpectedArrivalTime" minOccurs="0"/>
+   <xsd:element name="LatestExpectedArrivalTime" type="xsd:dateTime" minOccurs="0">
+    <xsd:annotation>
+     <xsd:documentation>Latest time at which a VEHICLE will arrive at stop. +SIRI v2.1</xsd:documentation>
+    </xsd:annotation>
+   </xsd:element>
    <xsd:element name="ExpectedArrivalPredictionQuality" type="PredictionQualityStructure" minOccurs="0">
     <xsd:annotation>
-     <xsd:documentation>Prediction quality, either as approximate level, or more quantitayive percentile range of   predictions will  fall within a given range of times.  +SIRI v2.0 </xsd:documentation>
+     <xsd:documentation>Prediction quality, either as approximate level, or more quantitative percentile range of predictions that will fall within a given range of times. +SIRI v2.0 </xsd:documentation>
     </xsd:annotation>
    </xsd:element>
   </xsd:sequence>


### PR DESCRIPTION
Small harmonization between SM and ET functional service on CALL level. Description of the CR can be found here:
[SIRI SM/SIRI ET inconsistency](https://3.basecamp.com/3256016/buckets/9672657/messages/2476120872)