### PR TITLE
CR088: SIRI FM - Site filter addition

### DIFF
--- a/xsd/siri_facilityMonitoring_service.xsd
+++ b/xsd/siri_facilityMonitoring_service.xsd
@@ -199,6 +199,11 @@ Rail transport, Roads and road transport
      <xsd:documentation>Reference to a stop place component.</xsd:documentation>
     </xsd:annotation>
    </xsd:element>
+   <xsd:element ref="SiteRef" minOccurs="0">
+    <xsd:annotation>
+     <xsd:documentation>Reference to a Site.</xsd:documentation>
+    </xsd:annotation>
+   </xsd:element>
   </xsd:sequence>
  </xsd:group>
  <xsd:group name="FacilityMonitoringRequestPolicyGroup">

--- a/xsd/siri_facilityMonitoring_service.xsd
+++ b/xsd/siri_facilityMonitoring_service.xsd
@@ -172,7 +172,7 @@ Rail transport, Roads and road transport
   </xsd:annotation>
   <xsd:sequence>
    <xsd:element ref="FacilityRef" minOccurs="0" maxOccurs="unbounded"/>
-   <xsd:element ref="FeatureRef" minOccurs="0"/>
+   <xsd:element ref="FeatureRef" minOccurs="0" maxOccurs="unbounded"/>
    <xsd:element ref="LineRef" minOccurs="0"/>
    <xsd:element ref="StopPointRef" minOccurs="0"/>
    <xsd:element ref="ConnectionLinkRef" minOccurs="0"/>

--- a/xsd/siri_model/siri_reference-v2.0.xsd
+++ b/xsd/siri_model/siri_reference-v2.0.xsd
@@ -792,4 +792,23 @@ Values for these elements can be specified on an annual schedule and will be inh
   </xsd:sequence>
  </xsd:complexType>
  <!-- ======================================================================= -->
+<xsd:simpleType name="SiteCodeType">
+	<xsd:annotation>
+		<xsd:documentation>Identifier of a SITE</xsd:documentation>
+	</xsd:annotation>
+	<xsd:restriction base="xsd:NMTOKEN"/>
+</xsd:simpleType>
+<xsd:complexType name="siteRefStructure">
+	<xsd:annotation>
+		<xsd:documentation>Reference to a SITE</xsd:documentation>
+	</xsd:annotation>
+	<xsd:simpleContent>
+		<xsd:extension base="SiteCodeType"/>
+	</xsd:simpleContent>
+</xsd:complexType>
+<xsd:element name="SiteRef" type="SiteRefStructure">
+	<xsd:annotation>
+		<xsd:documentation>Reference to a SITE</xsd:documentation>
+	</xsd:annotation>
+</xsd:element>
 </xsd:schema>

--- a/xsd/siri_model/siri_reference-v2.0.xsd
+++ b/xsd/siri_model/siri_reference-v2.0.xsd
@@ -798,7 +798,7 @@ Values for these elements can be specified on an annual schedule and will be inh
 	</xsd:annotation>
 	<xsd:restriction base="xsd:NMTOKEN"/>
 </xsd:simpleType>
-<xsd:complexType name="siteRefStructure">
+<xsd:complexType name="SiteRefStructure">
 	<xsd:annotation>
 		<xsd:documentation>Reference to a SITE</xsd:documentation>
 	</xsd:annotation>


### PR DESCRIPTION
Complement to CR71 to be able to filter by Site in SIRI FM (SITE generalisation was introduced by Transmodel after the definition of SIRI FM, and only STOP PLACE and STOP PLACE COMPONENT were the only SITE related available filters at that time).