### PR TITLE
Item List for item counting

### DIFF
--- a/xsd/siri_model/siri_facility-v2.0.xsd
+++ b/xsd/siri_model/siri_facility-v2.0.xsd
@@ -451,6 +451,20 @@ Rail transport, Roads and road transport
      <xsd:documentation>Description of what is counted</xsd:documentation>
     </xsd:annotation>
    </xsd:element>
+   <xsd:element name="CountedItemsIdList" minOccurs="0">
+	<xsd:annotation>
+		<xsd:documentation>List of the IDs of the counted items: usefull mainly for reservation and detailed information purposes</xsd:documentation>
+	</xsd:annotation>
+	<xsd:complexType>
+		<xsd:sequence>
+			<xsd:element name="ItemId" type="IdType" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>IDs of a counted item</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+   </xsd:element>
    <xsd:element ref="Extensions" minOccurs="0"/>
   </xsd:sequence>
  </xsd:complexType>


### PR DESCRIPTION
Small addition to CR71: list of the IDs of the counted items (usefull mainly for reservation and detailed information purposes).  
This is required for compatibility and mapping with existing interfaces (JC Decaux interface in France for example).
If the PR is accepted, I will update the docuement accordingly right away.