### PR TITLE
Alignments for SX: AffectedLine.Origins / Quality(Index)Enumeration

### DIFF
--- a/xsd/siri.xsd
+++ b/xsd/siri.xsd
@@ -390,12 +390,12 @@ Rail transport, Roads and road transport.
      <xsd:element ref="StopTimetableDelivery" maxOccurs="unbounded"/>
      <xsd:element ref="StopMonitoringDelivery" maxOccurs="unbounded">
       <xsd:annotation>
-       <xsd:documentation>Delviery for Stop Event service.</xsd:documentation>
+       <xsd:documentation>Delivery for Stop Event service.</xsd:documentation>
       </xsd:annotation>
      </xsd:element>
      <xsd:element ref="VehicleMonitoringDelivery" maxOccurs="unbounded">
       <xsd:annotation>
-       <xsd:documentation>Delviery for Vehicle Activity Service.</xsd:documentation>
+       <xsd:documentation>Delivery for Vehicle Activity Service.</xsd:documentation>
       </xsd:annotation>
      </xsd:element>
      <xsd:element ref="ConnectionTimetableDelivery" maxOccurs="unbounded"/>

--- a/xsd/siri.xsd
+++ b/xsd/siri.xsd
@@ -363,7 +363,7 @@ Rail transport, Roads and road transport.
    <xsd:group ref="ServiceDeliveryRequestStatusGroup"/>
    <xsd:element name="MoreData" type="xsd:boolean" default="false" minOccurs="0">
     <xsd:annotation>
-     <xsd:documentation>Whether there is a further delvery message with more current updates that follows this one. Default is 'false'.</xsd:documentation>
+     <xsd:documentation>Whether there is a further delivery message with more current updates that follows this one. Default is 'false'.</xsd:documentation>
     </xsd:annotation>
    </xsd:element>
    <xsd:group ref="SiriServiceDeliveryGroup"/>

--- a/xsd/siri/siri_base-v2.0.xsd
+++ b/xsd/siri/siri_base-v2.0.xsd
@@ -197,7 +197,7 @@ Rail transport, Roads and road transport.
    <xsd:element ref="DataReceivedAcknowledgement"/>
   </xsd:choice>
  </xsd:group>
- <!--===GS: Service Delviery -->
+ <!--===GS: Service Delivery -->
  <xsd:element name="ServiceDelivery">
   <xsd:annotation>
    <xsd:documentation>Response from Producer to Consumer to deliver payload data. Either answers a direct ServiceRequest, or asynchronously satisfies a subscription. May be sent directly in one step, or fetched in response to a DataSupply Request.</xsd:documentation>

--- a/xsd/siri_estimatedTimetable_service.xsd
+++ b/xsd/siri_estimatedTimetable_service.xsd
@@ -38,7 +38,7 @@
 				</Date>
     <Date><Modified>2012-03-23</Modified>
 					 +SIRI v2.0
-					   - Add EstimatedServiceJourneyInterchange (i.e. Estimated Connection of VEHICLE) to EstimatedTimetableDelviery
+					   - Add EstimatedServiceJourneyInterchange (i.e. Estimated Connection of VEHICLE) to EstimatedTimetableDelivery
 					   - [FR]    Add Extensions tag to EstimatedTimetableSubscriptionRequest
 					   - [DE] Add ExpectedDeparturePredictionQuality to OnwardVehicleDepartureTimes
 					     [DE] Correct capabilites matrix to matx doc. Add defauklt preview intervakl and versionref

--- a/xsd/siri_model/siri_situation-v2.0.xsd
+++ b/xsd/siri_model/siri_situation-v2.0.xsd
@@ -603,7 +603,7 @@ Rail transport, Roads and road transport
      <xsd:documentation>ProgressStatus. One of a specified set of overall processing states assigned to SITUATION. For example, 'Draft' for not yet published; 'Published' for live SITUATIONs; 'Closed' indicates a completed SITUATION.</xsd:documentation>
     </xsd:annotation>
    </xsd:element>
-   <xsd:element name="QualityIndex" type="QualityEnumeration" minOccurs="0">
+   <xsd:element name="QualityIndex" type="QualityIndexEnumeration" default="reliable" minOccurs="0">
     <xsd:annotation>
      <xsd:documentation>Assessement of likely correctness of data.</xsd:documentation>
     </xsd:annotation>
@@ -644,18 +644,6 @@ Rail transport, Roads and road transport
    <xsd:documentation>Type for Publication status.</xsd:documentation>
   </xsd:annotation>
   <xsd:restriction base="xsd:NMTOKEN"/>
- </xsd:simpleType>
- <xsd:simpleType name="QualityEnumeration">
-  <xsd:annotation>
-   <xsd:documentation>Type for Quality of data indication.  </xsd:documentation>
-  </xsd:annotation>
-  <xsd:restriction base="xsd:string">
-   <xsd:enumeration value="certain"/>
-   <xsd:enumeration value="veryReliable"/>
-   <xsd:enumeration value="reliable"/>
-   <xsd:enumeration value="probablyReliable"/>
-   <xsd:enumeration value="unconfirmed"/>
-  </xsd:restriction>
  </xsd:simpleType>
  <!-- ===Time=========================================== -->
  <xsd:group name="TemporalGroup">

--- a/xsd/siri_model/siri_situationAffects-v2.0.xsd
+++ b/xsd/siri_model/siri_situationAffects-v2.0.xsd
@@ -585,6 +585,11 @@ Rail transport, Roads and road transport
     </xsd:annotation>
    </xsd:element>
    <xsd:group ref="LineGroup"/>
+   <xsd:element name="Origins" type="AffectedStopPointStructure" minOccurs="0" maxOccurs="unbounded">
+    <xsd:annotation>
+     <xsd:documentation>ORIGINs to which the  LINE runs.</xsd:documentation>
+    </xsd:annotation>
+   </xsd:element>
    <xsd:element name="Destinations" type="AffectedStopPointStructure" minOccurs="0" maxOccurs="unbounded">
     <xsd:annotation>
      <xsd:documentation>DESTINATIONs to which the  LINE runs.</xsd:documentation>

--- a/xsd/siri_stopMonitoring_service.xsd
+++ b/xsd/siri_stopMonitoring_service.xsd
@@ -621,7 +621,7 @@ If false each subscription response will contain the full information as specifi
  </xsd:complexType>
  <xsd:complexType name="DeliveryVariantStructure">
   <xsd:annotation>
-   <xsd:documentation>Type for Delviery Variant +SIRI v2.0</xsd:documentation>
+   <xsd:documentation>Type for Delivery Variant +SIRI v2.0</xsd:documentation>
   </xsd:annotation>
   <xsd:sequence>
    <xsd:element name="VariantType" type="xsd:normalizedString" minOccurs="0">


### PR DESCRIPTION
Adding AffectedLine.Origins for SX https://3.basecamp.com/3256016/buckets/9672657/messages/3547803651
and
Alignment in Quality(Index)Enumeration
- Reuse QualityIndexEnumeration from siri_journey_support-v2.0.xsd and delete QualityEnumeration in siri_situation-v2.0.xsd
- Set default in SX Use (PtSituationElement.QualityIndex)
![image](https://user-images.githubusercontent.com/1889203/110440122-9a89ec00-80b8-11eb-9de0-8f2f74565bf2.png)
