### PR TITLE
Issues#78: add new occupancy/capacity model also to PreviousCall of VM and add choice for Monitored-/OnwardCall

### DIFF
--- a/xsd/siri_model/siri_journey.xsd
+++ b/xsd/siri_model/siri_journey.xsd
@@ -34,35 +34,35 @@
     <Date>
      <Modified>2012-03-22</Modified>
      <!-- SIRI 2.0 
-					[VDV] Add EarliestExpectedArrivalTimeForVehicle to Arrival Times Group
-					[VDV] Add ProvisionalExpectedDepartureTime to Departure Times Group
-					[VDV] Add LatestExpectedArrivalTimeForVehicle to Departure Times Group
-					[VDV] Add ViaPriority to ViaNames using a new ViaNameStructure SIRI-PT, SIRI-ET, SIRI-SM. SIRI-VM
-					[VDV] Add Velocity to MonitoredVehicleJourney SIRI-SM and SIRI-VM	
-					Add JOURNEY PARTs to Vehicle INFO TODO
-					[VDV] Add Public and Contact Details to JourneyInfo : SIRI-PT, SIRI-ET, SIRI-SM. SIRI-VM
-					[VDV] at DirectionAtOrigin name to JourneyInfo SIRI-PT, SIRI-ET, SIRI-SM. SIRI-VM
-					
-					[MTA] Add ArrivalProximityText to Arrival Times on MonitoredCall and OnwardsCall : SIRI-SM and SIRI-VM
-					[MTA] Add ArrivalProximityText to Departure Times on MonitoredCall and OnwardsCall : SIRI-SM and SIRI-VM
-					
-					[FR] Add AimedLatestPassengerAccessTime to TargetedCall : SIRI-ST
-					[FR] Add AimedLatestPassengerAccessTime to MonitoredCall and OnwardsCall : SIRI-SM and SIRI-VM
-					[FR] Add ExpectedLatestPassengerAccessTime to MonitoredCall and OnwardsCall : SIRI-SM and SIRI-VM
-					[FR] add ArrivalOperatorRefs and DepartureOperatorRefs to Call arrival and  Departure
-
-					[Fr] Add FirstOrLastJourney to JourneyTimesGroup : SIRI-SM and SIRI-VM
-					[DE] Add Driver Name
-					-->
+          [VDV] Add EarliestExpectedArrivalTimeForVehicle to Arrival Times Group
+          [VDV] Add ProvisionalExpectedDepartureTime to Departure Times Group
+          [VDV] Add LatestExpectedArrivalTimeForVehicle to Departure Times Group
+          [VDV] Add ViaPriority to ViaNames using a new ViaNameStructure SIRI-PT, SIRI-ET, SIRI-SM. SIRI-VM
+          [VDV] Add Velocity to MonitoredVehicleJourney SIRI-SM and SIRI-VM	
+          Add JOURNEY PARTs to Vehicle INFO TODO
+          [VDV] Add Public and Contact Details to JourneyInfo : SIRI-PT, SIRI-ET, SIRI-SM. SIRI-VM
+          [VDV] at DirectionAtOrigin name to JourneyInfo SIRI-PT, SIRI-ET, SIRI-SM. SIRI-VM
+          
+          [MTA] Add ArrivalProximityText to Arrival Times on MonitoredCall and OnwardsCall : SIRI-SM and SIRI-VM
+          [MTA] Add ArrivalProximityText to Departure Times on MonitoredCall and OnwardsCall : SIRI-SM and SIRI-VM
+          
+          [FR] Add AimedLatestPassengerAccessTime to TargetedCall : SIRI-ST
+          [FR] Add AimedLatestPassengerAccessTime to MonitoredCall and OnwardsCall : SIRI-SM and SIRI-VM
+          [FR] Add ExpectedLatestPassengerAccessTime to MonitoredCall and OnwardsCall : SIRI-SM and SIRI-VM
+          [FR] add ArrivalOperatorRefs and DepartureOperatorRefs to Call arrival and  Departure
+          
+          [Fr] Add FirstOrLastJourney to JourneyTimesGroup : SIRI-SM and SIRI-VM
+          [DE] Add Driver Name
+          -->
     </Date>
     <Date>
      <Modified>2012-04-27</Modified>
      <!-- SIRI 2.0 
-					[MTA] Add DistanceFromSTop and NumberOFStops away   to  MonitoredCall and OnwardsCall : SIRI-SM and SIRI-ET		
-					[NeTEx] Add Driver/Crew Ref		 
+          [MTA] Add DistanceFromSTop and NumberOFStops away   to  MonitoredCall and OnwardsCall : SIRI-SM and SIRI-ET		
+          [NeTEx] Add Driver/Crew Ref		 
           
-					[DE] Add ExpectedDeparturePredictionQuality to OnwardVehicleDepartureTimes
-					-->
+          [DE] Add ExpectedDeparturePredictionQuality to OnwardVehicleDepartureTimes
+          -->
     </Date>
     <Date>
      <Modified>2013-01-25</Modified>
@@ -93,10 +93,10 @@
     <Relation>
      <Requires>http://www.siri.org.uk/schema/2.0/xsd/siri_utility/siri_types.xsd</Requires>
     </Relation>
-    <Rights><!--Unclassified-->
-
-       <Copyright>CEN, VDV, RTIG 2004-2021</Copyright>
-				</Rights>
+    <Rights>
+     <!--Unclassified-->
+     <Copyright>CEN, VDV, RTIG 2004-2021</Copyright>
+    </Rights>
     <Source>
      <ul>
       <li>Derived from the VDV, RTIG CML and Trident standards.</li>
@@ -501,8 +501,16 @@ Rail transport, Roads and road transport
    <xsd:element name="DepartureStopAssignment" type="StopAssignmentStructure" minOccurs="0" maxOccurs="unbounded"/>
    <xsd:element ref="DepartureFormationAssignment" minOccurs="0" maxOccurs="unbounded"/>
    <xsd:element ref="DepartureOrientationRelativeToQuay" minOccurs="0" maxOccurs="unbounded"/>
-   <xsd:element ref="ExpectedDepartureOccupancy" minOccurs="0" maxOccurs="unbounded"/>
-   <xsd:element ref="ExpectedDepartureCapacities" minOccurs="0" maxOccurs="unbounded"/>
+   <xsd:choice>
+    <xsd:sequence>
+     <xsd:element ref="ExpectedDepartureOccupancy" minOccurs="0" maxOccurs="unbounded"/>
+     <xsd:element ref="ExpectedDepartureCapacities" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:sequence>
+     <xsd:element ref="RecordedDepartureOccupancy" minOccurs="0" maxOccurs="unbounded"/>
+     <xsd:element ref="RecordedDepartureCapacities" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+   </xsd:choice>
    <xsd:element ref="DepartureOperatorRefs" minOccurs="0" maxOccurs="unbounded"/>
   </xsd:sequence>
  </xsd:group>
@@ -1062,27 +1070,27 @@ It is advised to specify a reference point that is meaningful for passengers on 
  </xsd:element>
  <xsd:element name="ExpectedDepartureOccupancy" type="VehicleOccupancyStructure">
   <xsd:annotation>
-   <xsd:documentation>Real-time occupancies of a VEHICLE and reservations after departing from a given stop. +SIRI v2.1</xsd:documentation>
+   <xsd:documentation>Expected/Predicted real-time occupancies of a VEHICLE and reservations after departing from a given stop. +SIRI v2.1</xsd:documentation>
   </xsd:annotation>
  </xsd:element>
  <xsd:element name="ExpectedDepartureCapacities" type="PassengerCapacityStructure">
   <xsd:annotation>
-   <xsd:documentation>Real-time capacities (number of available seats) of a VEHICLE after departing from a given stop. Alternative way to communicate occupancy measurements. +SIRI v2.1</xsd:documentation>
+   <xsd:documentation>Expected/Predicted real-time capacities (number of available seats) of a VEHICLE after departing from a given stop. Alternative way to communicate occupancy measurements. +SIRI v2.1</xsd:documentation>
+  </xsd:annotation>
+ </xsd:element>
+ <xsd:element name="RecordedDepartureOccupancy" type="VehicleOccupancyStructure">
+  <xsd:annotation>
+   <xsd:documentation>Actually recorded/counted occupancies of a VEHICLE and reserved seats after departing from a given stop. +SIRI v2.1</xsd:documentation>
+  </xsd:annotation>
+ </xsd:element>
+ <xsd:element name="RecordedDepartureCapacities" type="PassengerCapacityStructure">
+  <xsd:annotation>
+   <xsd:documentation>Actually recorded/counted capacities of a VEHICLE after departing from a given stop. Alternative way to communicate occupancy measurements. +SIRI v2.1</xsd:documentation>
   </xsd:annotation>
  </xsd:element>
  <xsd:element name="DepartureOperatorRefs" type="OperatorRefStructure">
   <xsd:annotation>
    <xsd:documentation>OPERATORs of service for departure and onwards. May change from that for arrival. +SIRI v2.0.</xsd:documentation>
-  </xsd:annotation>
- </xsd:element>
- <xsd:element name="RecordedDepartureOccupancy" type="VehicleOccupancyStructure">
-  <xsd:annotation>
-   <xsd:documentation>Recorded occupancies of a VEHICLE and reserved seats after departing from a given stop. +SIRI v2.1</xsd:documentation>
-  </xsd:annotation>
- </xsd:element>
- <xsd:element name="RecordedDepartureCapacities" type="PassengerCapacityStructure">
-  <xsd:annotation>
-   <xsd:documentation>Recorded capacities of a VEHICLE after departing from a given stop. Alternative way to communicate occupancy measurements. +SIRI v2.1</xsd:documentation>
   </xsd:annotation>
  </xsd:element>
  <!-- ======================================================================= -->

--- a/xsd/siri_model/siri_monitoredVehicleJourney.xsd
+++ b/xsd/siri_model/siri_monitoredVehicleJourney.xsd
@@ -23,42 +23,47 @@
     <Date>
      <Modified>2007-03-29</Modified>
     </Date>
-    <Date><Modified>2008-11-13</Modified>
-				<!--Correct Cardinalities on SIRI DESTINATION REF Structure--> 
-				</Date>
-    <Date><Modified>2011-04-18</Modified>
-				<!--siri_journey.xsd (l.1015). FramedVehicleJourneyRef isn't mandatory in MonitoredCall SIRI-SM answer accourding to CEN TS (prCEN/TS 15531-3:2006 (E) p.56). Make optional. RV ixxx.com-->
-				</Date>
-    <Date><Modified>2012-03-22</Modified>
-				<!--SIRI 2.0 
-					[VDV] Add EarliestExpectedArrivalTimeForVehicle to Arrival Times Group
-					[VDV] Add ProvisionalExpectedDepartureTime to Departure Times Group
-					[VDV] Add LatestExpectedArrivalTimeForVehicle to Departure Times Group
-		
-					[Fr] Add FirstOrLastJourney to JourneyTimesGroup : SIRI-SM and SIRI-VM
-					Add JOURNEY PARTs to Vehicle INFO TODO
-					[VDV] Add Public and Contact Details to JourneyInfo : SIRI-PT, SIRI-ET, SIRI-SM. SIRI-VM
-					[VDV] at DirectionAtOrigin name to JourneyInfo SIRI-PT, SIRI-ET, SIRI-SM. SIRI-VM
-					
-					[MTA] Add ArrivalProximityText to Arrival Times on MonitoredCall and OnwardsCall : SIRI-SM and SIRI-VM
-					[MTA] Add ArrivalProximityText to Departure Times on MonitoredCall and OnwardsCall : SIRI-SM and SIRI-VM
-					
-					[FR] Add AimedLatestPassengerAccessTime to TargetedCall : SIRI-ST
-					[FR] Add AimedLatestPassengerAccessTime to MonitoredCall and OnwardsCall : SIRI-SM and SIRI-VM
-					[FR] Add ExpectedLatestPassengerAccessTime to MonitoredCall and OnwardsCall : SIRI-SM and SIRI-VM
-					
-					[VDV] Add ViaPriority to ViaNames using a new ViaNameStructure SIRI-PT, SIRI-ET, SIRI-SM. SIRI-VM
-					[VDV] Add Velocity to MonitoredVehicleJourney SIRI-SM and SIRI-VM
-					[UK] add engineOn to vehicle progress group-->
-				</Date>
-    <Date><Modified>2012-04-27</Modified>
-				<!--SIRI 2.0 
-					[MTA] Add DIstanceFromSTop and NumberOfStops away   to  MonitoredCall and OnwardsCall : SIRI-SM and SIRI-ET-->				 
-				</Date>
-    <Date><Modified>2012-04-27</Modified>
-				<!--SIRI 2.0 
-					[SE] Add Vehicle Status-->
-				</Date>
+    <Date>
+     <Modified>2008-11-13</Modified>
+     <!--Correct Cardinalities on SIRI DESTINATION REF Structure--> 
+    </Date>
+    <Date>
+     <Modified>2011-04-18</Modified>
+     <!--siri_journey.xsd (l.1015). FramedVehicleJourneyRef isn't mandatory in MonitoredCall SIRI-SM answer accourding to CEN TS (prCEN/TS 15531-3:2006 (E) p.56). Make optional. RV ixxx.com-->
+    </Date>
+    <Date>
+     <Modified>2012-03-22</Modified>
+     <!--SIRI 2.0 
+         [VDV] Add EarliestExpectedArrivalTimeForVehicle to Arrival Times Group
+         [VDV] Add ProvisionalExpectedDepartureTime to Departure Times Group
+         [VDV] Add LatestExpectedArrivalTimeForVehicle to Departure Times Group
+         
+         [Fr] Add FirstOrLastJourney to JourneyTimesGroup : SIRI-SM and SIRI-VM
+         Add JOURNEY PARTs to Vehicle INFO TODO
+         [VDV] Add Public and Contact Details to JourneyInfo : SIRI-PT, SIRI-ET, SIRI-SM. SIRI-VM
+         [VDV] at DirectionAtOrigin name to JourneyInfo SIRI-PT, SIRI-ET, SIRI-SM. SIRI-VM
+         
+         [MTA] Add ArrivalProximityText to Arrival Times on MonitoredCall and OnwardsCall : SIRI-SM and SIRI-VM
+         [MTA] Add ArrivalProximityText to Departure Times on MonitoredCall and OnwardsCall : SIRI-SM and SIRI-VM
+         
+         [FR] Add AimedLatestPassengerAccessTime to TargetedCall : SIRI-ST
+         [FR] Add AimedLatestPassengerAccessTime to MonitoredCall and OnwardsCall : SIRI-SM and SIRI-VM
+         [FR] Add ExpectedLatestPassengerAccessTime to MonitoredCall and OnwardsCall : SIRI-SM and SIRI-VM
+         
+         [VDV] Add ViaPriority to ViaNames using a new ViaNameStructure SIRI-PT, SIRI-ET, SIRI-SM. SIRI-VM
+         [VDV] Add Velocity to MonitoredVehicleJourney SIRI-SM and SIRI-VM
+         [UK] add engineOn to vehicle progress group-->
+    </Date>
+    <Date>
+     <Modified>2012-04-27</Modified>
+     <!--SIRI 2.0 
+         [MTA] Add DIstanceFromSTop and NumberOfStops away   to  MonitoredCall and OnwardsCall : SIRI-SM and SIRI-ET-->				 
+    </Date>
+    <Date>
+     <Modified>2012-04-27</Modified>
+     <!--SIRI 2.0 
+         [SE] Add Vehicle Status-->
+    </Date>
     <Description>
      <p>SIRI is a European CEN technical standard for the exchange of real-time information .</p>
      <p>This subschema defines common journey elements.</p>
@@ -74,10 +79,10 @@
     <Relation>
      <Requires>http://www.siri.org.uk/schema/2.0/xsd/siri_utility/siri_types.xsd</Requires>
     </Relation>
-    <Rights><!--Unclassified-->
-
-       <Copyright>CEN, VDV, RTIG 2004-2021</Copyright>
-				</Rights>
+    <Rights>
+     <!--Unclassified-->
+     <Copyright>CEN, VDV, RTIG 2004-2021</Copyright>
+    </Rights>
     <Source>
      <ul>
       <li>Derived from the VDV, RTIG CML and Trident standards.</li>
@@ -509,6 +514,8 @@ A journey does always have one or more JOURNEY PARTs for which the train formati
      <xsd:element ref="VehicleAtStop" minOccurs="0"/>
      <xsd:group ref="VehicleArrivalTimesGroup"/>
      <xsd:group ref="VehicleDepartureTimesGroup"/>
+     <xsd:element ref="RecordedDepartureOccupancy" minOccurs="0" maxOccurs="unbounded"/>
+     <xsd:element ref="RecordedDepartureCapacities" minOccurs="0" maxOccurs="unbounded"/>
      <xsd:element ref="Extensions" minOccurs="0"/>
     </xsd:sequence>
    </xsd:extension>


### PR DESCRIPTION
As requested in issue #78, small bug fix after merge of PullRequest #37, or [CR046](https://3.basecamp.com/3256016/buckets/9672657/uploads/1616871644) respectively, to:

- also add the following two elements (that were added in  in PreviousCall of VehicleMonitoring:
![XMLSpy_Xl0k6QIlwS](https://user-images.githubusercontent.com/54021300/156367858-14171c44-6a74-459f-96b4-f6985251258d.png)

- add choice between Recorded- and ExpectedDepartureOccupancy/-Capacities in Monitored- and OnwardCall (the latter unfortunately also applies the changes to EstimatedCall of ET, something that needs to be considered in the SIRI EU profile):
![XMLSpy_YAaTONpJRd](https://user-images.githubusercontent.com/54021300/156368928-df6502d3-072c-429f-8c7b-99eeedd1cb3a.png)
![XMLSpy_1fdQjhOGbA](https://user-images.githubusercontent.com/54021300/156368944-6e2c14b6-f999-4de5-9056-12b002351284.png)

