### PR TITLE
issues/88: make TotalNumberOfReservedSeats optional

### DIFF
--- a/xsd/siri_model/siri_journey.xsd
+++ b/xsd/siri_model/siri_journey.xsd
@@ -1522,7 +1522,7 @@ More accurate data can be provided by the individual occupancies or capacities b
   <xsd:sequence>
    <xsd:group ref="OccupancyScopeFilterGroup"/>
    <xsd:group ref="OccupancyValuesGroup"/>
-   <xsd:element name="TotalNumberOfReservedSeats" type="NumberOfPassengers">
+   <xsd:element name="TotalNumberOfReservedSeats" type="NumberOfPassengers" minOccurs="0" >
     <xsd:annotation>
      <xsd:documentation>Total number of booked seats from individual and group reservations.</xsd:documentation>
     </xsd:annotation>


### PR DESCRIPTION
See https://github.com/SIRI-CEN/SIRI/issues/88
The multiplicity of TotalNumberOfReservedSeats in VehicleOccupancyStructure that was introduced in https://github.com/SIRI-CEN/SIRI/pull/37 is not explicitly defined which results in it being mandatory. This in itself is an error because we have to consider at least two cases for which the specification of TotalNumberOfReservedSeats leads to wrong customer information:

- reservation is not possible for vehicle / journey
- reservation information is not available / unknown

On the other hand, according to the update of the SIRI documentation v2.1 the multiplicity is optional, i.e. differs from the XSD schema.