### PR TITLE
CR046: add missing references in TrainFormationReferenceGroup

### DIFF
--- a/xsd/siri_model/siri_journey_support.xsd
+++ b/xsd/siri_model/siri_journey_support.xsd
@@ -495,8 +495,14 @@ Has the following uses:
   </xsd:annotation>
   <xsd:sequence>
    <xsd:element ref="CompoundTrainRef" minOccurs="0"/>
-   <xsd:element ref="TrainRef" minOccurs="0"/>
-   <xsd:element ref="TrainComponentRef" minOccurs="0"/>
+   <xsd:choice>
+    <xsd:element ref="TrainRef" minOccurs="0"/>
+    <xsd:element ref="TrainInCompoundTrainRef" minOccurs="0"/>
+   </xsd:choice>
+   <xsd:choice>
+    <xsd:element ref="TrainElementRef" minOccurs="0"/>
+    <xsd:element ref="TrainComponentRef" minOccurs="0"/>
+   </xsd:choice>
    <xsd:element ref="EntranceToVehicleRef" minOccurs="0"/>
   </xsd:sequence>
  </xsd:group>


### PR DESCRIPTION
In implementations where a Train is defined in the following way (TrainComponent doesn't have an ID) a *DepartureOccupancy (via newly added VehicleOccupancyStructure) per coach was not possible because TrainElementRef was missing in TrainFormationReferenceGroup:
`
<Train>
 <TrainCode>cen:Train:g-a219f577-1263-48eb-8e66-d6632e32f7f7</TrainCode>
  <Components>
   <TrainComponent>
    <Order>1</Order>
    <TrainElementRef>cen:TrainElement:fz-b2915517-fc3c-4b0a-9975-14fecfaf41f6</TrainElementRef>
   </TrainComponent>
  ... 
`