### PR TITLE
Adding taxi mode

### DIFF
--- a/xsd/siri_model/siri_reference.xsd
+++ b/xsd/siri_model/siri_reference.xsd
@@ -348,6 +348,7 @@ Rail transport, Roads and road transport
    <xsd:enumeration value="ferry"/>
    <xsd:enumeration value="metro"/>
    <xsd:enumeration value="rail"/>
+   <xsd:enumeration value="taxi"/>
    <xsd:enumeration value="tram"/>
    <xsd:enumeration value="underground"/>
   </xsd:restriction>


### PR DESCRIPTION
Sometimes, e.g. a rail-replacement service or a low-occupancy bus route, is serviced by a taxi instead of a bus. It would be useful if the SIRI-data could reflect this so that e.g. a specific icon could be used. The suggested change applies to several SIRI datatypes (ET, VM, PT ++).

Possible issues could be that 
1. The `VehicleModesEnumeration` that this is a part of is described as "MODEs of transport applicable to timetabled public transport."
2.  Also, taxi is already part of `ContinuousModesEnumeration` described as "MODEs of transport applicable to private and non-timetabled transport."

With this in mind - is `taxi` an acceptable name here? Would e.g. `schedulableTaxi` or similar be a better choice?