### PR TITLE
Fixing bug in siri_situation.xsd (Publication attribute as an open type)

### DIFF
--- a/xsd/siri_model/siri_situation.xsd
+++ b/xsd/siri_model/siri_situation.xsd
@@ -620,7 +620,7 @@ Rail transport, Roads and road transport
    </xsd:element>
    <xsd:element name="Publication" type="PublicationStatusType" minOccurs="0" maxOccurs="unbounded">
     <xsd:annotation>
-     <xsd:documentation>Publishing status one of a specified set of substates to which a SITUATION can be assigned.</xsd:documentation>
+     <xsd:documentation>DEPRECATED -  Use the element Progress instead, which provides an enumeration of possible values detailed in WorkflowStatusEnumeration. -- Publishing status one of a specified set of substates to which a SITUATION can be assigned.</xsd:documentation>
     </xsd:annotation>
    </xsd:element>
   </xsd:sequence>
@@ -641,7 +641,7 @@ Rail transport, Roads and road transport
  </xsd:simpleType>
  <xsd:simpleType name="PublicationStatusType">
   <xsd:annotation>
-   <xsd:documentation>Type for Publication status.</xsd:documentation>
+   <xsd:documentation>DEPRECATED -  Use the element Progress instead, which provides an enumeration of possible values detailed in WorkflowStatusEnumeration. -- Type for Publication status.</xsd:documentation>
   </xsd:annotation>
   <xsd:restriction base="xsd:NMTOKEN"/>
  </xsd:simpleType>

--- a/xsd/siri_model/siri_situation.xsd
+++ b/xsd/siri_model/siri_situation.xsd
@@ -641,7 +641,7 @@ Rail transport, Roads and road transport
  </xsd:simpleType>
  <xsd:simpleType name="PublicationStatusType">
   <xsd:annotation>
-   <xsd:documentation>DEPRECATED -  Use the element Progress instead, which provides an enumeration of possible values detailed in WorkflowStatusEnumeration. -- Type for Publication status.</xsd:documentation>
+   <xsd:documentation>DEPRECATED -  Type for Publication status.</xsd:documentation>
   </xsd:annotation>
   <xsd:restriction base="xsd:NMTOKEN"/>
  </xsd:simpleType>


### PR DESCRIPTION
Attribute `Publication`as an open type was deemed a bug. To define the publication status, it is advised to use `Progress` with the values detailed in `WorkflowStatusEnumeration`

Refer to discussion in [Basecamp](https://3.basecamp.com/3256016/buckets/9672657/messages/8233981953)

Note: I chose to mark it as DEPRECATED instead of deleting it, but happy to do it differently. 