### PR TITLE
Service link proposal

### DIFF
--- a/docs/generated/contab/acsb.html
+++ b/docs/generated/contab/acsb.html
@@ -248,7 +248,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-27.1" title="local-type: typedef-27.1">local-type: typedef-27.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-25.1" title="local-type: typedef-25.1">local-type: typedef-25.1</a>
                       </em>
                     </p>
                   </td>
@@ -272,7 +272,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-27.2" title="local-type: typedef-27.2">local-type: typedef-27.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-25.2" title="local-type: typedef-25.2">local-type: typedef-25.2</a>
                       </em>
                     </p>
                   </td>
@@ -297,7 +297,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-71.1" title="local-type: typedef-71.1">local-type: typedef-71.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-8.1" title="local-type: typedef-8.1">local-type: typedef-8.1</a>
                       </em>
                     </p>
                   </td>
@@ -544,7 +544,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-71.1" title="local-type: typedef-71.1">local-type: typedef-71.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-8.1" title="local-type: typedef-8.1">local-type: typedef-8.1</a>
                       </em>
                     </p>
                   </td>
@@ -589,8 +589,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-27.1">
-          <h3>1.6. The complex type <code>complexType[acsb:AccessibilityAssessmentStructure]/Limitations#complexType (typedef-27.1)</code>
+        <div class="sect2" id="local-type.typedef-25.1">
+          <h3>1.6. The complex type <code>complexType[acsb:AccessibilityAssessmentStructure]/Limitations#complexType (typedef-25.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -610,7 +610,7 @@
                       <br/>
                       <code>  /Limitations #complexType</code>
                       <br/>
-                      <code>  (typedef-27.1)</code>
+                      <code>  (typedef-25.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -652,8 +652,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-27.2">
-          <h3>1.7. The complex type <code>complexType[acsb:AccessibilityAssessmentStructure]/Suitabilities#complexType (typedef-27.2)</code>
+        <div class="sect2" id="local-type.typedef-25.2">
+          <h3>1.7. The complex type <code>complexType[acsb:AccessibilityAssessmentStructure]/Suitabilities#complexType (typedef-25.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -673,7 +673,7 @@
                       <br/>
                       <code>  /Suitabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-27.2)</code>
+                      <code>  (typedef-25.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -715,8 +715,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-71.1">
-          <h3>1.8. The complex type <code>element[ifopt:Extensions]#complexType (typedef-71.1)</code>
+        <div class="sect2" id="local-type.typedef-8.1">
+          <h3>1.8. The complex type <code>element[ifopt:Extensions]#complexType (typedef-8.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -736,7 +736,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-71.1)</code>
+                      <code>  (typedef-8.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -752,8 +752,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-71.1">
-          <h3>1.9. The complex type <code>element[ifopt:Extensions]#complexType (typedef-71.1)</code>
+        <div class="sect2" id="local-type.typedef-8.1">
+          <h3>1.9. The complex type <code>element[ifopt:Extensions]#complexType (typedef-8.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -773,7 +773,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-71.1)</code>
+                      <code>  (typedef-8.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -1672,12 +1672,12 @@
                 </tr>
                 <tr>
                   <td colspan="1" rowspan="2" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-25.1" class="tableblock">
+                    <p id="local-type.typedef-27.1" class="tableblock">
                       <code>group[acsb:UserNeedGroup]</code>
                       <br/>
                       <code>  /MedicalNeed #simpleType</code>
                       <br/>
-                      <code>  (typedef-25.1)</code>
+                      <code>  (typedef-27.1)</code>
                     </p>
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
@@ -1844,7 +1844,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/acsb.enum-dict.html#local-enum.typedef-25.1" title="local-type: typedef-25.1">local-type: typedef-25.1</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/acsb.enum-dict.html#local-enum.typedef-27.1" title="local-type: typedef-27.1">local-type: typedef-27.1</a>
                       </em>
                     </p>
                   </td>
@@ -2173,7 +2173,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/acsb.enum-dict.html#local-enum.typedef-25.1" title="local-type: typedef-25.1">local-type: typedef-25.1</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/acsb.enum-dict.html#local-enum.typedef-27.1" title="local-type: typedef-27.1">local-type: typedef-27.1</a>
                       </em>
                     </p>
                   </td>

--- a/docs/generated/contab/datex2.html
+++ b/docs/generated/contab/datex2.html
@@ -107112,7 +107112,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-59.1" title="local-type: typedef-59.1">local-type: typedef-59.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-23.1" title="local-type: typedef-23.1">local-type: typedef-23.1</a>
                       </em>
                     </p>
                   </td>
@@ -111020,7 +111020,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-59.2" title="local-type: typedef-59.2">local-type: typedef-59.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-23.2" title="local-type: typedef-23.2">local-type: typedef-23.2</a>
                       </em>
                     </p>
                   </td>
@@ -111865,7 +111865,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-59.3" title="local-type: typedef-59.3">local-type: typedef-59.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-23.3" title="local-type: typedef-23.3">local-type: typedef-23.3</a>
                       </em>
                     </p>
                   </td>
@@ -127573,7 +127573,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-59.4" title="local-type: typedef-59.4">local-type: typedef-59.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-23.4" title="local-type: typedef-23.4">local-type: typedef-23.4</a>
                       </em>
                     </p>
                   </td>
@@ -145442,8 +145442,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-59.1">
-          <h3>2.327. The complex type <code>complexType[Itinerary]/locationContainedInItinerary#complexType (typedef-59.1)</code>
+        <div class="sect2" id="local-type.typedef-23.1">
+          <h3>2.327. The complex type <code>complexType[Itinerary]/locationContainedInItinerary#complexType (typedef-23.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -145463,7 +145463,7 @@
                       <br/>
                       <code>  /locationContainedInItinerary #complexType</code>
                       <br/>
-                      <code>  (typedef-59.1)</code>
+                      <code>  (typedef-23.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -145588,8 +145588,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-59.2">
-          <h3>2.328. The complex type <code>complexType[MeasurementSiteRecord]/measurementSpecificCharacteristics#complexType (typedef-59.2)</code>
+        <div class="sect2" id="local-type.typedef-23.2">
+          <h3>2.328. The complex type <code>complexType[MeasurementSiteRecord]/measurementSpecificCharacteristics#complexType (typedef-23.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -145609,7 +145609,7 @@
                       <br/>
                       <code>  /measurementSpecificCharacteristics #complexType</code>
                       <br/>
-                      <code>  (typedef-59.2)</code>
+                      <code>  (typedef-23.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -145839,8 +145839,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-59.3">
-          <h3>2.329. The complex type <code>complexType[MultilingualString]/values#complexType (typedef-59.3)</code>
+        <div class="sect2" id="local-type.typedef-23.3">
+          <h3>2.329. The complex type <code>complexType[MultilingualString]/values#complexType (typedef-23.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -145860,7 +145860,7 @@
                       <br/>
                       <code>  /values #complexType</code>
                       <br/>
-                      <code>  (typedef-59.3)</code>
+                      <code>  (typedef-23.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -145902,8 +145902,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-59.4">
-          <h3>2.330. The complex type <code>complexType[SiteMeasurements]/measuredValue#complexType (typedef-59.4)</code>
+        <div class="sect2" id="local-type.typedef-23.4">
+          <h3>2.330. The complex type <code>complexType[SiteMeasurements]/measuredValue#complexType (typedef-23.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -145923,7 +145923,7 @@
                       <br/>
                       <code>  /measuredValue #complexType</code>
                       <br/>
-                      <code>  (typedef-59.4)</code>
+                      <code>  (typedef-23.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">

--- a/docs/generated/contab/ifopt.html
+++ b/docs/generated/contab/ifopt.html
@@ -7206,7 +7206,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-63.1" title="local-type: typedef-63.1">local-type: typedef-63.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-9.1" title="local-type: typedef-9.1">local-type: typedef-9.1</a>
                       </em>
                     </p>
                   </td>
@@ -8212,7 +8212,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-63.1" title="local-type: typedef-63.1">local-type: typedef-63.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-9.1" title="local-type: typedef-9.1">local-type: typedef-9.1</a>
                       </em>
                     </p>
                   </td>
@@ -8237,7 +8237,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-71.1" title="local-type: typedef-71.1">local-type: typedef-71.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-8.1" title="local-type: typedef-8.1">local-type: typedef-8.1</a>
                       </em>
                     </p>
                   </td>
@@ -8562,7 +8562,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-71.1" title="local-type: typedef-71.1">local-type: typedef-71.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-8.1" title="local-type: typedef-8.1">local-type: typedef-8.1</a>
                       </em>
                     </p>
                   </td>
@@ -8574,8 +8574,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-63.1">
-          <h3>4.15. The complex type <code>group[ifopt:LocalServiceGroup]/FeatureRefs#complexType (typedef-63.1)</code>
+        <div class="sect2" id="local-type.typedef-9.1">
+          <h3>4.15. The complex type <code>group[ifopt:LocalServiceGroup]/FeatureRefs#complexType (typedef-9.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -8595,7 +8595,7 @@
                       <br/>
                       <code>  /FeatureRefs #complexType</code>
                       <br/>
-                      <code>  (typedef-63.1)</code>
+                      <code>  (typedef-9.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -8633,8 +8633,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-63.1">
-          <h3>4.16. The complex type <code>group[ifopt:LocalServiceGroup]/FeatureRefs#complexType (typedef-63.1)</code>
+        <div class="sect2" id="local-type.typedef-9.1">
+          <h3>4.16. The complex type <code>group[ifopt:LocalServiceGroup]/FeatureRefs#complexType (typedef-9.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -8654,7 +8654,7 @@
                       <br/>
                       <code>  /FeatureRefs #complexType</code>
                       <br/>
-                      <code>  (typedef-63.1)</code>
+                      <code>  (typedef-9.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -8692,8 +8692,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-71.1">
-          <h3>4.17. The complex type <code>element[ifopt:Extensions]#complexType (typedef-71.1)</code>
+        <div class="sect2" id="local-type.typedef-8.1">
+          <h3>4.17. The complex type <code>element[ifopt:Extensions]#complexType (typedef-8.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -8713,7 +8713,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-71.1)</code>
+                      <code>  (typedef-8.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -8729,8 +8729,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-71.1">
-          <h3>4.18. The complex type <code>element[ifopt:Extensions]#complexType (typedef-71.1)</code>
+        <div class="sect2" id="local-type.typedef-8.1">
+          <h3>4.18. The complex type <code>element[ifopt:Extensions]#complexType (typedef-8.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -8750,7 +8750,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-71.1)</code>
+                      <code>  (typedef-8.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -9391,7 +9391,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.1" title="local-type: typedef-64.1">local-type: typedef-64.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-14.1" title="local-type: typedef-14.1">local-type: typedef-14.1</a>
                       </em>
                     </p>
                   </td>
@@ -9568,7 +9568,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.1" title="local-type: typedef-64.1">local-type: typedef-64.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-14.1" title="local-type: typedef-14.1">local-type: typedef-14.1</a>
                       </em>
                     </p>
                   </td>
@@ -9597,7 +9597,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.2" title="local-type: typedef-64.2">local-type: typedef-64.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-14.2" title="local-type: typedef-14.2">local-type: typedef-14.2</a>
                       </em>
                     </p>
                   </td>
@@ -9659,7 +9659,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.1" title="local-type: typedef-64.1">local-type: typedef-64.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-14.1" title="local-type: typedef-14.1">local-type: typedef-14.1</a>
                       </em>
                     </p>
                   </td>
@@ -9908,7 +9908,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.1" title="local-type: typedef-64.1">local-type: typedef-64.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-14.1" title="local-type: typedef-14.1">local-type: typedef-14.1</a>
                       </em>
                     </p>
                   </td>
@@ -9941,7 +9941,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.3" title="local-type: typedef-64.3">local-type: typedef-64.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-14.3" title="local-type: typedef-14.3">local-type: typedef-14.3</a>
                       </em>
                     </p>
                   </td>
@@ -9953,8 +9953,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.1">
-          <h3>5.17. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-64.1)</code>
+        <div class="sect2" id="local-type.typedef-14.1">
+          <h3>5.17. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-14.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -9974,7 +9974,7 @@
                       <br/>
                       <code>  /Features #complexType</code>
                       <br/>
-                      <code>  (typedef-64.1)</code>
+                      <code>  (typedef-14.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -10016,8 +10016,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.1">
-          <h3>5.18. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-64.1)</code>
+        <div class="sect2" id="local-type.typedef-14.1">
+          <h3>5.18. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-14.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -10037,7 +10037,7 @@
                       <br/>
                       <code>  /Features #complexType</code>
                       <br/>
-                      <code>  (typedef-64.1)</code>
+                      <code>  (typedef-14.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -10079,8 +10079,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.2">
-          <h3>5.19. The complex type <code>complexType[ifopt:LinkProjectionStructure]/Line#complexType (typedef-64.2)</code>
+        <div class="sect2" id="local-type.typedef-14.2">
+          <h3>5.19. The complex type <code>complexType[ifopt:LinkProjectionStructure]/Line#complexType (typedef-14.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -10100,7 +10100,7 @@
                       <br/>
                       <code>  /Line #complexType</code>
                       <br/>
-                      <code>  (typedef-64.2)</code>
+                      <code>  (typedef-14.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -10143,8 +10143,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.1">
-          <h3>5.20. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-64.1)</code>
+        <div class="sect2" id="local-type.typedef-14.1">
+          <h3>5.20. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-14.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -10164,7 +10164,7 @@
                       <br/>
                       <code>  /Features #complexType</code>
                       <br/>
-                      <code>  (typedef-64.1)</code>
+                      <code>  (typedef-14.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -10206,8 +10206,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.1">
-          <h3>5.21. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-64.1)</code>
+        <div class="sect2" id="local-type.typedef-14.1">
+          <h3>5.21. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-14.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -10227,7 +10227,7 @@
                       <br/>
                       <code>  /Features #complexType</code>
                       <br/>
-                      <code>  (typedef-64.1)</code>
+                      <code>  (typedef-14.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -10269,8 +10269,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.3">
-          <h3>5.22. The complex type <code>complexType[ifopt:ZoneProjectionStructure]/Boundary#complexType (typedef-64.3)</code>
+        <div class="sect2" id="local-type.typedef-14.3">
+          <h3>5.22. The complex type <code>complexType[ifopt:ZoneProjectionStructure]/Boundary#complexType (typedef-14.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -10290,7 +10290,7 @@
                       <br/>
                       <code>  /Boundary #complexType</code>
                       <br/>
-                      <code>  (typedef-64.3)</code>
+                      <code>  (typedef-14.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -13149,7 +13149,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-68.1" title="local-type: typedef-68.1">local-type: typedef-68.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-17.1" title="local-type: typedef-17.1">local-type: typedef-17.1</a>
                       </em>
                     </p>
                   </td>
@@ -13161,8 +13161,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-68.1">
-          <h3>10.5. The complex type <code>complexType[ifopt:ValidityConditionStructure]/Timebands#complexType (typedef-68.1)</code>
+        <div class="sect2" id="local-type.typedef-17.1">
+          <h3>10.5. The complex type <code>complexType[ifopt:ValidityConditionStructure]/Timebands#complexType (typedef-17.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -13182,7 +13182,7 @@
                       <br/>
                       <code>  /Timebands #complexType</code>
                       <br/>
-                      <code>  (typedef-68.1)</code>
+                      <code>  (typedef-17.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -13416,8 +13416,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-71.1">
-          <h3>11.7. The complex type <code>element[ifopt:Extensions]#complexType (typedef-71.1)</code>
+        <div class="sect2" id="local-type.typedef-8.1">
+          <h3>11.7. The complex type <code>element[ifopt:Extensions]#complexType (typedef-8.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -13437,7 +13437,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-71.1)</code>
+                      <code>  (typedef-8.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">

--- a/docs/generated/contab/siri.html
+++ b/docs/generated/contab/siri.html
@@ -5215,7 +5215,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-1.1" title="local-type: typedef-1.1">local-type: typedef-1.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
                       </em>
                     </p>
                   </td>
@@ -5624,7 +5624,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
                       </em>
                     </p>
                   </td>
@@ -5655,7 +5655,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-6.2" title="local-type: typedef-6.2">local-type: typedef-6.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-33.2" title="local-type: typedef-33.2">local-type: typedef-33.2</a>
                       </em>
                     </p>
                   </td>
@@ -6041,7 +6041,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.4" title="local-type: typedef-72.4">local-type: typedef-72.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.4" title="local-type: typedef-77.4">local-type: typedef-77.4</a>
                       </em>
                     </p>
                   </td>
@@ -6637,7 +6637,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.4" title="local-type: typedef-72.4">local-type: typedef-72.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.4" title="local-type: typedef-77.4">local-type: typedef-77.4</a>
                       </em>
                     </p>
                   </td>
@@ -6743,7 +6743,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
                       </em>
                     </p>
                   </td>
@@ -6774,7 +6774,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.3" title="local-type: typedef-72.3">local-type: typedef-72.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.3" title="local-type: typedef-77.3">local-type: typedef-77.3</a>
                       </em>
                     </p>
                   </td>
@@ -7023,7 +7023,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.1" title="local-type: typedef-74.1">local-type: typedef-74.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-72.1" title="local-type: typedef-72.1">local-type: typedef-72.1</a>
                       </em>
                     </p>
                   </td>
@@ -7085,7 +7085,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.2" title="local-type: typedef-74.2">local-type: typedef-74.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
                       </em>
                     </p>
                   </td>
@@ -7416,7 +7416,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.4" title="local-type: typedef-72.4">local-type: typedef-72.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.4" title="local-type: typedef-77.4">local-type: typedef-77.4</a>
                       </em>
                     </p>
                   </td>
@@ -7856,7 +7856,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-1.1" title="local-type: typedef-1.1">local-type: typedef-1.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
                       </em>
                     </p>
                   </td>
@@ -8350,7 +8350,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
                       </em>
                     </p>
                   </td>
@@ -8381,7 +8381,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.3" title="local-type: typedef-72.3">local-type: typedef-72.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.3" title="local-type: typedef-77.3">local-type: typedef-77.3</a>
                       </em>
                     </p>
                   </td>
@@ -8653,7 +8653,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.1" title="local-type: typedef-74.1">local-type: typedef-74.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-72.1" title="local-type: typedef-72.1">local-type: typedef-72.1</a>
                       </em>
                     </p>
                   </td>
@@ -8715,7 +8715,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.2" title="local-type: typedef-74.2">local-type: typedef-74.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
                       </em>
                     </p>
                   </td>
@@ -9252,7 +9252,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-84.3" title="local-type: typedef-84.3">local-type: typedef-84.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-78.3" title="local-type: typedef-78.3">local-type: typedef-78.3</a>
                       </em>
                     </p>
                   </td>
@@ -10566,7 +10566,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-84.2" title="local-type: typedef-84.2">local-type: typedef-84.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-78.2" title="local-type: typedef-78.2">local-type: typedef-78.2</a>
                       </em>
                     </p>
                   </td>
@@ -11113,7 +11113,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-84.3" title="local-type: typedef-84.3">local-type: typedef-84.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-78.3" title="local-type: typedef-78.3">local-type: typedef-78.3</a>
                       </em>
                     </p>
                   </td>
@@ -11872,7 +11872,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-1.1" title="local-type: typedef-1.1">local-type: typedef-1.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
                       </em>
                     </p>
                   </td>
@@ -12574,7 +12574,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-1.1" title="local-type: typedef-1.1">local-type: typedef-1.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
                       </em>
                     </p>
                   </td>
@@ -14090,7 +14090,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-84.2" title="local-type: typedef-84.2">local-type: typedef-84.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-78.2" title="local-type: typedef-78.2">local-type: typedef-78.2</a>
                       </em>
                     </p>
                   </td>
@@ -14709,7 +14709,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-84.2" title="local-type: typedef-84.2">local-type: typedef-84.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-78.2" title="local-type: typedef-78.2">local-type: typedef-78.2</a>
                       </em>
                     </p>
                   </td>
@@ -15000,8 +15000,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.4">
-          <h3>1.28. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-72.4)</code>
+        <div class="sect2" id="local-type.typedef-77.4">
+          <h3>1.28. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-77.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -15021,7 +15021,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.4)</code>
+                      <code>  (typedef-77.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -15265,7 +15265,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-1.1" title="local-type: typedef-1.1">local-type: typedef-1.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
                       </em>
                     </p>
                   </td>
@@ -15326,8 +15326,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-1.1">
-          <h3>1.29. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-1.1)</code>
+        <div class="sect2" id="local-type.typedef-34.1">
+          <h3>1.29. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -15347,7 +15347,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-1.1)</code>
+                      <code>  (typedef-34.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -15458,8 +15458,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.2">
-          <h3>1.30. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-72.2)</code>
+        <div class="sect2" id="local-type.typedef-77.2">
+          <h3>1.30. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-77.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -15479,7 +15479,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.2)</code>
+                      <code>  (typedef-77.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -15713,8 +15713,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.1">
-          <h3>1.31. The complex type <code>element[siri:Siri]#complexType (typedef-72.1)</code>
+        <div class="sect2" id="local-type.typedef-77.1">
+          <h3>1.31. The complex type <code>element[siri:Siri]#complexType (typedef-77.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -15734,7 +15734,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.1)</code>
+                      <code>  (typedef-77.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -15814,7 +15814,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
                       </em>
                     </p>
                   </td>
@@ -15845,7 +15845,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-6.2" title="local-type: typedef-6.2">local-type: typedef-6.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-33.2" title="local-type: typedef-33.2">local-type: typedef-33.2</a>
                       </em>
                     </p>
                   </td>
@@ -16231,7 +16231,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.4" title="local-type: typedef-72.4">local-type: typedef-72.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.4" title="local-type: typedef-77.4">local-type: typedef-77.4</a>
                       </em>
                     </p>
                   </td>
@@ -16413,8 +16413,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.2">
-          <h3>1.32. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-72.2)</code>
+        <div class="sect2" id="local-type.typedef-77.2">
+          <h3>1.32. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-77.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -16434,7 +16434,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.2)</code>
+                      <code>  (typedef-77.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -16668,8 +16668,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-6.2">
-          <h3>1.33. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-6.2)</code>
+        <div class="sect2" id="local-type.typedef-33.2">
+          <h3>1.33. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-33.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -16689,7 +16689,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-6.2)</code>
+                      <code>  (typedef-33.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -16997,8 +16997,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.4">
-          <h3>1.34. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-72.4)</code>
+        <div class="sect2" id="local-type.typedef-77.4">
+          <h3>1.34. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-77.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -17018,7 +17018,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.4)</code>
+                      <code>  (typedef-77.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -17262,7 +17262,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-1.1" title="local-type: typedef-1.1">local-type: typedef-1.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
                       </em>
                     </p>
                   </td>
@@ -17323,8 +17323,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-1.1">
-          <h3>1.35. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-1.1)</code>
+        <div class="sect2" id="local-type.typedef-34.1">
+          <h3>1.35. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -17344,7 +17344,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-1.1)</code>
+                      <code>  (typedef-34.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -17455,8 +17455,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.3">
-          <h3>1.36. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-72.3)</code>
+        <div class="sect2" id="local-type.typedef-77.3">
+          <h3>1.36. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-77.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -17476,7 +17476,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.3)</code>
+                      <code>  (typedef-77.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -17784,8 +17784,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.4">
-          <h3>1.37. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-72.4)</code>
+        <div class="sect2" id="local-type.typedef-77.4">
+          <h3>1.37. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-77.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -17805,7 +17805,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.4)</code>
+                      <code>  (typedef-77.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -18049,7 +18049,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-1.1" title="local-type: typedef-1.1">local-type: typedef-1.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
                       </em>
                     </p>
                   </td>
@@ -18110,8 +18110,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-1.1">
-          <h3>1.38. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-1.1)</code>
+        <div class="sect2" id="local-type.typedef-34.1">
+          <h3>1.38. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -18131,7 +18131,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-1.1)</code>
+                      <code>  (typedef-34.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -18242,8 +18242,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.2">
-          <h3>1.39. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-72.2)</code>
+        <div class="sect2" id="local-type.typedef-77.2">
+          <h3>1.39. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-77.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -18263,7 +18263,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.2)</code>
+                      <code>  (typedef-77.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -18497,8 +18497,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.3">
-          <h3>1.40. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-72.3)</code>
+        <div class="sect2" id="local-type.typedef-77.3">
+          <h3>1.40. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-77.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -18518,7 +18518,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.3)</code>
+                      <code>  (typedef-77.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -18826,8 +18826,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.1">
-          <h3>1.41. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-74.1)</code>
+        <div class="sect2" id="local-type.typedef-72.1">
+          <h3>1.41. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-72.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -18847,7 +18847,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.1)</code>
+                      <code>  (typedef-72.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -19237,8 +19237,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.2">
-          <h3>1.42. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-74.2)</code>
+        <div class="sect2" id="local-type.typedef-72.2">
+          <h3>1.42. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-72.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -19258,7 +19258,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.2)</code>
+                      <code>  (typedef-72.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -19476,8 +19476,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.4">
-          <h3>1.43. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-72.4)</code>
+        <div class="sect2" id="local-type.typedef-77.4">
+          <h3>1.43. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-77.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -19497,7 +19497,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.4)</code>
+                      <code>  (typedef-77.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -19741,7 +19741,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-1.1" title="local-type: typedef-1.1">local-type: typedef-1.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
                       </em>
                     </p>
                   </td>
@@ -19802,8 +19802,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-1.1">
-          <h3>1.44. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-1.1)</code>
+        <div class="sect2" id="local-type.typedef-34.1">
+          <h3>1.44. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -19823,7 +19823,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-1.1)</code>
+                      <code>  (typedef-34.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -19934,8 +19934,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-1.1">
-          <h3>1.45. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-1.1)</code>
+        <div class="sect2" id="local-type.typedef-34.1">
+          <h3>1.45. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -19955,7 +19955,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-1.1)</code>
+                      <code>  (typedef-34.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -20066,8 +20066,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.2">
-          <h3>1.46. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-72.2)</code>
+        <div class="sect2" id="local-type.typedef-77.2">
+          <h3>1.46. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-77.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -20087,7 +20087,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.2)</code>
+                      <code>  (typedef-77.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -20321,8 +20321,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.3">
-          <h3>1.47. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-72.3)</code>
+        <div class="sect2" id="local-type.typedef-77.3">
+          <h3>1.47. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-77.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -20342,7 +20342,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.3)</code>
+                      <code>  (typedef-77.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -20650,8 +20650,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.1">
-          <h3>1.48. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-74.1)</code>
+        <div class="sect2" id="local-type.typedef-72.1">
+          <h3>1.48. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-72.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -20671,7 +20671,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.1)</code>
+                      <code>  (typedef-72.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -21061,8 +21061,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.2">
-          <h3>1.49. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-74.2)</code>
+        <div class="sect2" id="local-type.typedef-72.2">
+          <h3>1.49. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-72.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -21082,7 +21082,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.2)</code>
+                      <code>  (typedef-72.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -21300,8 +21300,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-84.3">
-          <h3>1.50. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-84.3)</code>
+        <div class="sect2" id="local-type.typedef-78.3">
+          <h3>1.50. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-78.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -21321,7 +21321,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-84.3)</code>
+                      <code>  (typedef-78.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -21471,8 +21471,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-84.2">
-          <h3>1.51. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-84.2)</code>
+        <div class="sect2" id="local-type.typedef-78.2">
+          <h3>1.51. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-78.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -21492,7 +21492,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-84.2)</code>
+                      <code>  (typedef-78.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -21689,8 +21689,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-84.3">
-          <h3>1.52. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-84.3)</code>
+        <div class="sect2" id="local-type.typedef-78.3">
+          <h3>1.52. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-78.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -21710,7 +21710,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-84.3)</code>
+                      <code>  (typedef-78.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -21860,8 +21860,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-1.1">
-          <h3>1.53. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-1.1)</code>
+        <div class="sect2" id="local-type.typedef-34.1">
+          <h3>1.53. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -21881,7 +21881,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-1.1)</code>
+                      <code>  (typedef-34.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -21992,8 +21992,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-1.1">
-          <h3>1.54. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-1.1)</code>
+        <div class="sect2" id="local-type.typedef-34.1">
+          <h3>1.54. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -22013,7 +22013,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-1.1)</code>
+                      <code>  (typedef-34.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -22124,8 +22124,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-84.2">
-          <h3>1.55. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-84.2)</code>
+        <div class="sect2" id="local-type.typedef-78.2">
+          <h3>1.55. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-78.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -22145,7 +22145,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-84.2)</code>
+                      <code>  (typedef-78.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -22342,8 +22342,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-84.2">
-          <h3>1.56. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-84.2)</code>
+        <div class="sect2" id="local-type.typedef-78.2">
+          <h3>1.56. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-78.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -22363,7 +22363,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-84.2)</code>
+                      <code>  (typedef-78.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -22892,7 +22892,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-1.1" title="local-type: typedef-1.1">local-type: typedef-1.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
                       </em>
                     </p>
                   </td>
@@ -23652,7 +23652,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.4" title="local-type: typedef-72.4">local-type: typedef-72.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.4" title="local-type: typedef-77.4">local-type: typedef-77.4</a>
                       </em>
                     </p>
                   </td>
@@ -23960,7 +23960,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
                       </em>
                     </p>
                   </td>
@@ -23991,7 +23991,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.3" title="local-type: typedef-72.3">local-type: typedef-72.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.3" title="local-type: typedef-77.3">local-type: typedef-77.3</a>
                       </em>
                     </p>
                   </td>
@@ -24408,7 +24408,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.4" title="local-type: typedef-72.4">local-type: typedef-72.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.4" title="local-type: typedef-77.4">local-type: typedef-77.4</a>
                       </em>
                     </p>
                   </td>
@@ -24623,7 +24623,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-1.1" title="local-type: typedef-1.1">local-type: typedef-1.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
                       </em>
                     </p>
                   </td>
@@ -24742,7 +24742,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
                       </em>
                     </p>
                   </td>
@@ -24773,7 +24773,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.3" title="local-type: typedef-72.3">local-type: typedef-72.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.3" title="local-type: typedef-77.3">local-type: typedef-77.3</a>
                       </em>
                     </p>
                   </td>
@@ -25533,7 +25533,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-1.1" title="local-type: typedef-1.1">local-type: typedef-1.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
                       </em>
                     </p>
                   </td>
@@ -26235,7 +26235,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-1.1" title="local-type: typedef-1.1">local-type: typedef-1.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
                       </em>
                     </p>
                   </td>
@@ -27017,7 +27017,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
                       </em>
                     </p>
                   </td>
@@ -27048,7 +27048,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.3" title="local-type: typedef-72.3">local-type: typedef-72.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.3" title="local-type: typedef-77.3">local-type: typedef-77.3</a>
                       </em>
                     </p>
                   </td>
@@ -27297,7 +27297,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.1" title="local-type: typedef-74.1">local-type: typedef-74.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-72.1" title="local-type: typedef-72.1">local-type: typedef-72.1</a>
                       </em>
                     </p>
                   </td>
@@ -27359,7 +27359,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.2" title="local-type: typedef-74.2">local-type: typedef-74.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
                       </em>
                     </p>
                   </td>
@@ -27659,7 +27659,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.4" title="local-type: typedef-72.4">local-type: typedef-72.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.4" title="local-type: typedef-77.4">local-type: typedef-77.4</a>
                       </em>
                     </p>
                   </td>
@@ -28396,8 +28396,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-6.3">
-          <h3>2.21. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-6.3)</code>
+        <div class="sect2" id="local-type.typedef-33.3">
+          <h3>2.21. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-33.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -28417,7 +28417,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-6.3)</code>
+                      <code>  (typedef-33.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -28661,7 +28661,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-1.1" title="local-type: typedef-1.1">local-type: typedef-1.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
                       </em>
                     </p>
                   </td>
@@ -28722,8 +28722,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-1.1">
-          <h3>2.22. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-1.1)</code>
+        <div class="sect2" id="local-type.typedef-34.1">
+          <h3>2.22. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -28743,7 +28743,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-1.1)</code>
+                      <code>  (typedef-34.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -28854,8 +28854,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-6.1">
-          <h3>2.23. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-6.1)</code>
+        <div class="sect2" id="local-type.typedef-33.1">
+          <h3>2.23. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-33.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -28875,7 +28875,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-6.1)</code>
+                      <code>  (typedef-33.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -29143,8 +29143,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-6.2">
-          <h3>2.24. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-6.2)</code>
+        <div class="sect2" id="local-type.typedef-33.2">
+          <h3>2.24. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-33.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -29164,7 +29164,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-6.2)</code>
+                      <code>  (typedef-33.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -29472,8 +29472,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.4">
-          <h3>2.25. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-72.4)</code>
+        <div class="sect2" id="local-type.typedef-77.4">
+          <h3>2.25. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-77.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -29493,7 +29493,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.4)</code>
+                      <code>  (typedef-77.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -29737,7 +29737,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-1.1" title="local-type: typedef-1.1">local-type: typedef-1.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
                       </em>
                     </p>
                   </td>
@@ -29798,8 +29798,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-1.1">
-          <h3>2.26. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-1.1)</code>
+        <div class="sect2" id="local-type.typedef-34.1">
+          <h3>2.26. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -29819,7 +29819,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-1.1)</code>
+                      <code>  (typedef-34.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -29930,8 +29930,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.2">
-          <h3>2.27. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-72.2)</code>
+        <div class="sect2" id="local-type.typedef-77.2">
+          <h3>2.27. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-77.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -29951,7 +29951,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.2)</code>
+                      <code>  (typedef-77.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -30185,8 +30185,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.3">
-          <h3>2.28. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-72.3)</code>
+        <div class="sect2" id="local-type.typedef-77.3">
+          <h3>2.28. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-77.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -30206,7 +30206,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.3)</code>
+                      <code>  (typedef-77.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -30514,8 +30514,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.4">
-          <h3>2.29. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-72.4)</code>
+        <div class="sect2" id="local-type.typedef-77.4">
+          <h3>2.29. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-77.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -30535,7 +30535,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.4)</code>
+                      <code>  (typedef-77.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -30779,7 +30779,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-1.1" title="local-type: typedef-1.1">local-type: typedef-1.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
                       </em>
                     </p>
                   </td>
@@ -30840,8 +30840,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-1.1">
-          <h3>2.30. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-1.1)</code>
+        <div class="sect2" id="local-type.typedef-34.1">
+          <h3>2.30. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -30861,7 +30861,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-1.1)</code>
+                      <code>  (typedef-34.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -30972,8 +30972,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-1.1">
-          <h3>2.31. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-1.1)</code>
+        <div class="sect2" id="local-type.typedef-34.1">
+          <h3>2.31. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -30993,7 +30993,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-1.1)</code>
+                      <code>  (typedef-34.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -31104,8 +31104,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.2">
-          <h3>2.32. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-72.2)</code>
+        <div class="sect2" id="local-type.typedef-77.2">
+          <h3>2.32. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-77.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -31125,7 +31125,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.2)</code>
+                      <code>  (typedef-77.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -31359,8 +31359,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.3">
-          <h3>2.33. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-72.3)</code>
+        <div class="sect2" id="local-type.typedef-77.3">
+          <h3>2.33. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-77.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -31380,7 +31380,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.3)</code>
+                      <code>  (typedef-77.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -31688,8 +31688,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-1.1">
-          <h3>2.34. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-1.1)</code>
+        <div class="sect2" id="local-type.typedef-34.1">
+          <h3>2.34. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -31709,7 +31709,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-1.1)</code>
+                      <code>  (typedef-34.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -31820,8 +31820,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-1.1">
-          <h3>2.35. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-1.1)</code>
+        <div class="sect2" id="local-type.typedef-34.1">
+          <h3>2.35. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -31841,7 +31841,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-1.1)</code>
+                      <code>  (typedef-34.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -31952,8 +31952,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.2">
-          <h3>2.36. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-72.2)</code>
+        <div class="sect2" id="local-type.typedef-77.2">
+          <h3>2.36. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-77.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -31973,7 +31973,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.2)</code>
+                      <code>  (typedef-77.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -32207,8 +32207,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.3">
-          <h3>2.37. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-72.3)</code>
+        <div class="sect2" id="local-type.typedef-77.3">
+          <h3>2.37. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-77.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -32228,7 +32228,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.3)</code>
+                      <code>  (typedef-77.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -32536,8 +32536,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.1">
-          <h3>2.38. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-74.1)</code>
+        <div class="sect2" id="local-type.typedef-72.1">
+          <h3>2.38. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-72.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -32557,7 +32557,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.1)</code>
+                      <code>  (typedef-72.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -32947,8 +32947,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.2">
-          <h3>2.39. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-74.2)</code>
+        <div class="sect2" id="local-type.typedef-72.2">
+          <h3>2.39. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-72.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -32968,7 +32968,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.2)</code>
+                      <code>  (typedef-72.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -33186,8 +33186,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.4">
-          <h3>2.40. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-72.4)</code>
+        <div class="sect2" id="local-type.typedef-77.4">
+          <h3>2.40. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-77.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -33207,7 +33207,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.4)</code>
+                      <code>  (typedef-77.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -33451,7 +33451,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-1.1" title="local-type: typedef-1.1">local-type: typedef-1.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
                       </em>
                     </p>
                   </td>
@@ -33512,8 +33512,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-1.1">
-          <h3>2.41. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-1.1)</code>
+        <div class="sect2" id="local-type.typedef-34.1">
+          <h3>2.41. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -33533,7 +33533,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-1.1)</code>
+                      <code>  (typedef-34.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -34222,7 +34222,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-3.4" title="local-type: typedef-3.4">local-type: typedef-3.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-29.4" title="local-type: typedef-29.4">local-type: typedef-29.4</a>
                       </em>
                     </p>
                   </td>
@@ -34488,7 +34488,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-3.3" title="local-type: typedef-3.3">local-type: typedef-3.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-29.3" title="local-type: typedef-29.3">local-type: typedef-29.3</a>
                       </em>
                     </p>
                   </td>
@@ -36728,7 +36728,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-3.4" title="local-type: typedef-3.4">local-type: typedef-3.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-29.4" title="local-type: typedef-29.4">local-type: typedef-29.4</a>
                       </em>
                     </p>
                   </td>
@@ -37066,7 +37066,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-3.4" title="local-type: typedef-3.4">local-type: typedef-3.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-29.4" title="local-type: typedef-29.4">local-type: typedef-29.4</a>
                       </em>
                     </p>
                   </td>
@@ -37981,7 +37981,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-3.2" title="local-type: typedef-3.2">local-type: typedef-3.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-29.2" title="local-type: typedef-29.2">local-type: typedef-29.2</a>
                       </em>
                     </p>
                   </td>
@@ -38188,7 +38188,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-3.3" title="local-type: typedef-3.3">local-type: typedef-3.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-29.3" title="local-type: typedef-29.3">local-type: typedef-29.3</a>
                       </em>
                     </p>
                   </td>
@@ -38826,7 +38826,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-3.4" title="local-type: typedef-3.4">local-type: typedef-3.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-29.4" title="local-type: typedef-29.4">local-type: typedef-29.4</a>
                       </em>
                     </p>
                   </td>
@@ -41303,7 +41303,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-3.1" title="local-type: typedef-3.1">local-type: typedef-3.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-29.1" title="local-type: typedef-29.1">local-type: typedef-29.1</a>
                       </em>
                     </p>
                   </td>
@@ -41315,8 +41315,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-3.4">
-          <h3>3.56. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-3.4)</code>
+        <div class="sect2" id="local-type.typedef-29.4">
+          <h3>3.56. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-29.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -41336,7 +41336,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-3.4)</code>
+                      <code>  (typedef-29.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -41447,8 +41447,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-3.3">
-          <h3>3.57. The complex type <code>group[siri:DataReceivedPayloadGroup]/ErrorCondition#complexType (typedef-3.3)</code>
+        <div class="sect2" id="local-type.typedef-29.3">
+          <h3>3.57. The complex type <code>group[siri:DataReceivedPayloadGroup]/ErrorCondition#complexType (typedef-29.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -41468,7 +41468,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-3.3)</code>
+                      <code>  (typedef-29.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -41579,8 +41579,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-3.4">
-          <h3>3.58. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-3.4)</code>
+        <div class="sect2" id="local-type.typedef-29.4">
+          <h3>3.58. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-29.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -41600,7 +41600,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-3.4)</code>
+                      <code>  (typedef-29.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -41711,8 +41711,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-3.4">
-          <h3>3.59. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-3.4)</code>
+        <div class="sect2" id="local-type.typedef-29.4">
+          <h3>3.59. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-29.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -41732,7 +41732,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-3.4)</code>
+                      <code>  (typedef-29.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -41843,8 +41843,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-3.2">
-          <h3>3.60. The complex type <code>complexType[siri:DataReadyResponseStructure]/ErrorCondition#complexType (typedef-3.2)</code>
+        <div class="sect2" id="local-type.typedef-29.2">
+          <h3>3.60. The complex type <code>complexType[siri:DataReadyResponseStructure]/ErrorCondition#complexType (typedef-29.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -41864,7 +41864,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-3.2)</code>
+                      <code>  (typedef-29.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -41975,8 +41975,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-3.3">
-          <h3>3.61. The complex type <code>group[siri:DataReceivedPayloadGroup]/ErrorCondition#complexType (typedef-3.3)</code>
+        <div class="sect2" id="local-type.typedef-29.3">
+          <h3>3.61. The complex type <code>group[siri:DataReceivedPayloadGroup]/ErrorCondition#complexType (typedef-29.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -41996,7 +41996,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-3.3)</code>
+                      <code>  (typedef-29.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -42107,8 +42107,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-3.4">
-          <h3>3.62. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-3.4)</code>
+        <div class="sect2" id="local-type.typedef-29.4">
+          <h3>3.62. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-29.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -42128,7 +42128,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-3.4)</code>
+                      <code>  (typedef-29.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -42239,8 +42239,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-3.1">
-          <h3>3.63. The complex type <code>complexType[siri:TerminationResponseStatusStructure]/ErrorCondition#complexType (typedef-3.1)</code>
+        <div class="sect2" id="local-type.typedef-29.1">
+          <h3>3.63. The complex type <code>complexType[siri:TerminationResponseStatusStructure]/ErrorCondition#complexType (typedef-29.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -42260,7 +42260,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-3.1)</code>
+                      <code>  (typedef-29.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -50127,7 +50127,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-1.1" title="local-type: typedef-1.1">local-type: typedef-1.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
                       </em>
                     </p>
                   </td>
@@ -52859,7 +52859,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-1.2" title="local-type: typedef-1.2">local-type: typedef-1.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-34.2" title="local-type: typedef-34.2">local-type: typedef-34.2</a>
                       </em>
                     </p>
                   </td>
@@ -52887,7 +52887,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-1.3" title="local-type: typedef-1.3">local-type: typedef-1.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-34.3" title="local-type: typedef-34.3">local-type: typedef-34.3</a>
                       </em>
                     </p>
                   </td>
@@ -55033,8 +55033,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-1.1">
-          <h3>6.64. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-1.1)</code>
+        <div class="sect2" id="local-type.typedef-34.1">
+          <h3>6.64. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -55054,7 +55054,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-1.1)</code>
+                      <code>  (typedef-34.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -55165,8 +55165,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-1.2">
-          <h3>6.65. The complex type <code>complexType[siri:CapabilityGeneralInteractionStructure]/Interaction#complexType (typedef-1.2)</code>
+        <div class="sect2" id="local-type.typedef-34.2">
+          <h3>6.65. The complex type <code>complexType[siri:CapabilityGeneralInteractionStructure]/Interaction#complexType (typedef-34.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -55186,7 +55186,7 @@
                       <br/>
                       <code>  /Interaction #complexType</code>
                       <br/>
-                      <code>  (typedef-1.2)</code>
+                      <code>  (typedef-34.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -55254,8 +55254,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-1.3">
-          <h3>6.66. The complex type <code>complexType[siri:CapabilityGeneralInteractionStructure]/Delivery#complexType (typedef-1.3)</code>
+        <div class="sect2" id="local-type.typedef-34.3">
+          <h3>6.66. The complex type <code>complexType[siri:CapabilityGeneralInteractionStructure]/Delivery#complexType (typedef-34.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -55275,7 +55275,7 @@
                       <br/>
                       <code>  /Delivery #complexType</code>
                       <br/>
-                      <code>  (typedef-1.3)</code>
+                      <code>  (typedef-34.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -57632,7 +57632,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.3" title="local-type: typedef-73.3">local-type: typedef-73.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.3" title="local-type: typedef-74.3">local-type: typedef-74.3</a>
                       </em>
                     </p>
                   </td>
@@ -59314,7 +59314,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.1" title="local-type: typedef-73.1">local-type: typedef-73.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.1" title="local-type: typedef-74.1">local-type: typedef-74.1</a>
                       </em>
                     </p>
                   </td>
@@ -59338,7 +59338,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.2" title="local-type: typedef-73.2">local-type: typedef-73.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.2" title="local-type: typedef-74.2">local-type: typedef-74.2</a>
                       </em>
                     </p>
                   </td>
@@ -61614,8 +61614,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.3">
-          <h3>7.37. The complex type <code>element[siri:ConnectionMonitoringPermissions]#complexType (typedef-73.3)</code>
+        <div class="sect2" id="local-type.typedef-74.3">
+          <h3>7.37. The complex type <code>element[siri:ConnectionMonitoringPermissions]#complexType (typedef-74.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -61635,7 +61635,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-73.3)</code>
+                      <code>  (typedef-74.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -61673,8 +61673,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.3">
-          <h3>7.38. The complex type <code>element[siri:ConnectionMonitoringPermissions]#complexType (typedef-73.3)</code>
+        <div class="sect2" id="local-type.typedef-74.3">
+          <h3>7.38. The complex type <code>element[siri:ConnectionMonitoringPermissions]#complexType (typedef-74.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -61694,7 +61694,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-73.3)</code>
+                      <code>  (typedef-74.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -61732,8 +61732,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.1">
-          <h3>7.39. The complex type <code>complexType[siri:ConnectionMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-73.1)</code>
+        <div class="sect2" id="local-type.typedef-74.1">
+          <h3>7.39. The complex type <code>complexType[siri:ConnectionMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-74.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -61753,7 +61753,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-73.1)</code>
+                      <code>  (typedef-74.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -61862,8 +61862,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.2">
-          <h3>7.40. The complex type <code>complexType[siri:ConnectionMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-73.2)</code>
+        <div class="sect2" id="local-type.typedef-74.2">
+          <h3>7.40. The complex type <code>complexType[siri:ConnectionMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-74.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -61883,7 +61883,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-73.2)</code>
+                      <code>  (typedef-74.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -63509,7 +63509,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.1" title="local-type: typedef-82.1">local-type: typedef-82.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.1" title="local-type: typedef-84.1">local-type: typedef-84.1</a>
                       </em>
                     </p>
                   </td>
@@ -64632,7 +64632,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.2" title="local-type: typedef-82.2">local-type: typedef-82.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.2" title="local-type: typedef-84.2">local-type: typedef-84.2</a>
                       </em>
                     </p>
                   </td>
@@ -64656,7 +64656,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.3" title="local-type: typedef-82.3">local-type: typedef-82.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.3" title="local-type: typedef-84.3">local-type: typedef-84.3</a>
                       </em>
                     </p>
                   </td>
@@ -65872,8 +65872,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.1">
-          <h3>8.26. The complex type <code>complexType[siri:ConnectionTimetableCapabilitiesResponseStructure]/ConnectionTimetablePermissions#complexType (typedef-82.1)</code>
+        <div class="sect2" id="local-type.typedef-84.1">
+          <h3>8.26. The complex type <code>complexType[siri:ConnectionTimetableCapabilitiesResponseStructure]/ConnectionTimetablePermissions#complexType (typedef-84.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -65893,7 +65893,7 @@
                       <br/>
                       <code>  /ConnectionTimetablePermissions #complexType</code>
                       <br/>
-                      <code>  (typedef-82.1)</code>
+                      <code>  (typedef-84.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -65967,8 +65967,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.2">
-          <h3>8.27. The complex type <code>complexType[siri:ConnectionTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-82.2)</code>
+        <div class="sect2" id="local-type.typedef-84.2">
+          <h3>8.27. The complex type <code>complexType[siri:ConnectionTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-84.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -65988,7 +65988,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-82.2)</code>
+                      <code>  (typedef-84.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -66058,8 +66058,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.3">
-          <h3>8.28. The complex type <code>complexType[siri:ConnectionTimetableServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-82.3)</code>
+        <div class="sect2" id="local-type.typedef-84.3">
+          <h3>8.28. The complex type <code>complexType[siri:ConnectionTimetableServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-84.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -66079,7 +66079,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-82.3)</code>
+                      <code>  (typedef-84.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -68403,7 +68403,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.1" title="local-type: typedef-74.1">local-type: typedef-74.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-72.1" title="local-type: typedef-72.1">local-type: typedef-72.1</a>
                       </em>
                     </p>
                   </td>
@@ -68465,7 +68465,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.2" title="local-type: typedef-74.2">local-type: typedef-74.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
                       </em>
                     </p>
                   </td>
@@ -69233,7 +69233,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.1" title="local-type: typedef-74.1">local-type: typedef-74.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-72.1" title="local-type: typedef-72.1">local-type: typedef-72.1</a>
                       </em>
                     </p>
                   </td>
@@ -69295,7 +69295,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.2" title="local-type: typedef-74.2">local-type: typedef-74.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
                       </em>
                     </p>
                   </td>
@@ -74315,8 +74315,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.2">
-          <h3>9.51. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-74.2)</code>
+        <div class="sect2" id="local-type.typedef-72.2">
+          <h3>9.51. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-72.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -74336,7 +74336,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.2)</code>
+                      <code>  (typedef-72.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -74554,8 +74554,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.1">
-          <h3>9.52. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-74.1)</code>
+        <div class="sect2" id="local-type.typedef-72.1">
+          <h3>9.52. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-72.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -74575,7 +74575,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.1)</code>
+                      <code>  (typedef-72.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -74965,8 +74965,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.1">
-          <h3>9.53. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-74.1)</code>
+        <div class="sect2" id="local-type.typedef-72.1">
+          <h3>9.53. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-72.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -74986,7 +74986,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.1)</code>
+                      <code>  (typedef-72.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -75376,8 +75376,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.2">
-          <h3>9.54. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-74.2)</code>
+        <div class="sect2" id="local-type.typedef-72.2">
+          <h3>9.54. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-72.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -75397,7 +75397,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.2)</code>
+                      <code>  (typedef-72.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -75615,8 +75615,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.1">
-          <h3>9.55. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-74.1)</code>
+        <div class="sect2" id="local-type.typedef-72.1">
+          <h3>9.55. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-72.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -75636,7 +75636,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.1)</code>
+                      <code>  (typedef-72.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -76026,8 +76026,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.2">
-          <h3>9.56. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-74.2)</code>
+        <div class="sect2" id="local-type.typedef-72.2">
+          <h3>9.56. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-72.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -76047,7 +76047,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.2)</code>
+                      <code>  (typedef-72.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -77100,7 +77100,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.1" title="local-type: typedef-78.1">local-type: typedef-78.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-85.1" title="local-type: typedef-85.1">local-type: typedef-85.1</a>
                       </em>
                     </p>
                   </td>
@@ -77593,7 +77593,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.4" title="local-type: typedef-78.4">local-type: typedef-78.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-85.4" title="local-type: typedef-85.4">local-type: typedef-85.4</a>
                       </em>
                     </p>
                   </td>
@@ -78507,7 +78507,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.1" title="local-type: typedef-78.1">local-type: typedef-78.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-85.1" title="local-type: typedef-85.1">local-type: typedef-85.1</a>
                       </em>
                     </p>
                   </td>
@@ -78840,7 +78840,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.2" title="local-type: typedef-78.2">local-type: typedef-78.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-85.2" title="local-type: typedef-85.2">local-type: typedef-85.2</a>
                       </em>
                     </p>
                   </td>
@@ -78864,7 +78864,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.3" title="local-type: typedef-78.3">local-type: typedef-78.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-85.3" title="local-type: typedef-85.3">local-type: typedef-85.3</a>
                       </em>
                     </p>
                   </td>
@@ -79380,8 +79380,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.4">
-          <h3>10.23. The complex type <code>element[siri:EstimatedTimetablePermissions]#complexType (typedef-78.4)</code>
+        <div class="sect2" id="local-type.typedef-85.4">
+          <h3>10.23. The complex type <code>element[siri:EstimatedTimetablePermissions]#complexType (typedef-85.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -79401,7 +79401,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-78.4)</code>
+                      <code>  (typedef-85.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -79475,8 +79475,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.1">
-          <h3>10.24. The complex type <code>group[siri:EstimatedTimetableTopicGroup]/Lines#complexType (typedef-78.1)</code>
+        <div class="sect2" id="local-type.typedef-85.1">
+          <h3>10.24. The complex type <code>group[siri:EstimatedTimetableTopicGroup]/Lines#complexType (typedef-85.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -79496,7 +79496,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-78.1)</code>
+                      <code>  (typedef-85.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -79538,8 +79538,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.4">
-          <h3>10.25. The complex type <code>element[siri:EstimatedTimetablePermissions]#complexType (typedef-78.4)</code>
+        <div class="sect2" id="local-type.typedef-85.4">
+          <h3>10.25. The complex type <code>element[siri:EstimatedTimetablePermissions]#complexType (typedef-85.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -79559,7 +79559,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-78.4)</code>
+                      <code>  (typedef-85.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -79633,8 +79633,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.1">
-          <h3>10.26. The complex type <code>group[siri:EstimatedTimetableTopicGroup]/Lines#complexType (typedef-78.1)</code>
+        <div class="sect2" id="local-type.typedef-85.1">
+          <h3>10.26. The complex type <code>group[siri:EstimatedTimetableTopicGroup]/Lines#complexType (typedef-85.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -79654,7 +79654,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-78.1)</code>
+                      <code>  (typedef-85.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -79696,8 +79696,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.2">
-          <h3>10.27. The complex type <code>complexType[siri:EstimatedTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-78.2)</code>
+        <div class="sect2" id="local-type.typedef-85.2">
+          <h3>10.27. The complex type <code>complexType[siri:EstimatedTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-85.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -79717,7 +79717,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-78.2)</code>
+                      <code>  (typedef-85.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -79907,8 +79907,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.3">
-          <h3>10.28. The complex type <code>complexType[siri:EstimatedTimetableServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-78.3)</code>
+        <div class="sect2" id="local-type.typedef-85.3">
+          <h3>10.28. The complex type <code>complexType[siri:EstimatedTimetableServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-85.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -79928,7 +79928,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-78.3)</code>
+                      <code>  (typedef-85.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81839,7 +81839,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-85.5" title="local-type: typedef-85.5">local-type: typedef-85.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.5" title="local-type: typedef-75.5">local-type: typedef-75.5</a>
                       </em>
                     </p>
                   </td>
@@ -83036,7 +83036,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-85.1" title="local-type: typedef-85.1">local-type: typedef-85.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.1" title="local-type: typedef-75.1">local-type: typedef-75.1</a>
                       </em>
                     </p>
                   </td>
@@ -83060,7 +83060,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-85.2" title="local-type: typedef-85.2">local-type: typedef-85.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.2" title="local-type: typedef-75.2">local-type: typedef-75.2</a>
                       </em>
                     </p>
                   </td>
@@ -83108,7 +83108,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-85.3" title="local-type: typedef-85.3">local-type: typedef-85.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.3" title="local-type: typedef-75.3">local-type: typedef-75.3</a>
                       </em>
                     </p>
                   </td>
@@ -83132,7 +83132,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-85.4" title="local-type: typedef-85.4">local-type: typedef-85.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.4" title="local-type: typedef-75.4">local-type: typedef-75.4</a>
                       </em>
                     </p>
                   </td>
@@ -83291,7 +83291,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-13.1" title="local-type: typedef-13.1">local-type: typedef-13.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
                       </em>
                     </p>
                   </td>
@@ -83325,7 +83325,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-43.2" title="local-type: typedef-43.2">local-type: typedef-43.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-56.2" title="local-type: typedef-56.2">local-type: typedef-56.2</a>
                       </em>
                     </p>
                   </td>
@@ -83354,7 +83354,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-43.1" title="local-type: typedef-43.1">local-type: typedef-43.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-56.1" title="local-type: typedef-56.1">local-type: typedef-56.1</a>
                       </em>
                     </p>
                   </td>
@@ -83610,8 +83610,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-85.5">
-          <h3>11.24. The complex type <code>element[siri:FacilityMonitoringPermissions]#complexType (typedef-85.5)</code>
+        <div class="sect2" id="local-type.typedef-75.5">
+          <h3>11.24. The complex type <code>element[siri:FacilityMonitoringPermissions]#complexType (typedef-75.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -83631,7 +83631,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-85.5)</code>
+                      <code>  (typedef-75.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -83705,8 +83705,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-85.5">
-          <h3>11.25. The complex type <code>element[siri:FacilityMonitoringPermissions]#complexType (typedef-85.5)</code>
+        <div class="sect2" id="local-type.typedef-75.5">
+          <h3>11.25. The complex type <code>element[siri:FacilityMonitoringPermissions]#complexType (typedef-75.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -83726,7 +83726,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-85.5)</code>
+                      <code>  (typedef-75.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -83800,8 +83800,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-85.1">
-          <h3>11.26. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-85.1)</code>
+        <div class="sect2" id="local-type.typedef-75.1">
+          <h3>11.26. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-75.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -83821,7 +83821,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-85.1)</code>
+                      <code>  (typedef-75.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -84086,8 +84086,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-85.2">
-          <h3>11.27. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-85.2)</code>
+        <div class="sect2" id="local-type.typedef-75.2">
+          <h3>11.27. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-75.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -84107,7 +84107,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-85.2)</code>
+                      <code>  (typedef-75.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -84279,8 +84279,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-85.3">
-          <h3>11.28. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/AccessControl#complexType (typedef-85.3)</code>
+        <div class="sect2" id="local-type.typedef-75.3">
+          <h3>11.28. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/AccessControl#complexType (typedef-75.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -84300,7 +84300,7 @@
                       <br/>
                       <code>  /AccessControl #complexType</code>
                       <br/>
-                      <code>  (typedef-85.3)</code>
+                      <code>  (typedef-75.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -84401,8 +84401,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-85.4">
-          <h3>11.29. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-85.4)</code>
+        <div class="sect2" id="local-type.typedef-75.4">
+          <h3>11.29. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-75.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -84422,7 +84422,7 @@
                       <br/>
                       <code>  /ResponseFeatures #complexType</code>
                       <br/>
-                      <code>  (typedef-85.4)</code>
+                      <code>  (typedef-75.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -84482,8 +84482,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-13.1">
-          <h3>11.30. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-13.1)</code>
+        <div class="sect2" id="local-type.typedef-36.1">
+          <h3>11.30. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-36.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -84503,7 +84503,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-13.1)</code>
+                      <code>  (typedef-36.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -84571,8 +84571,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-43.2">
-          <h3>11.31. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-43.2)</code>
+        <div class="sect2" id="local-type.typedef-56.2">
+          <h3>11.31. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-56.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -84592,7 +84592,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-43.2)</code>
+                      <code>  (typedef-56.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -84677,8 +84677,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-43.1">
-          <h3>11.32. The complex type <code>element[siri:LinePermissions]#complexType (typedef-43.1)</code>
+        <div class="sect2" id="local-type.typedef-56.1">
+          <h3>11.32. The complex type <code>element[siri:LinePermissions]#complexType (typedef-56.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -84698,7 +84698,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-43.1)</code>
+                      <code>  (typedef-56.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -87002,7 +87002,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-13.1" title="local-type: typedef-13.1">local-type: typedef-13.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
                       </em>
                     </p>
                   </td>
@@ -88138,8 +88138,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-13.1">
-          <h3>12.32. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-13.1)</code>
+        <div class="sect2" id="local-type.typedef-36.1">
+          <h3>12.32. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-36.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -88159,7 +88159,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-13.1)</code>
+                      <code>  (typedef-36.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -92454,7 +92454,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-55.6" title="local-type: typedef-55.6">local-type: typedef-55.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.6" title="local-type: typedef-57.6">local-type: typedef-57.6</a>
                       </em>
                     </p>
                   </td>
@@ -92475,7 +92475,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-55.7" title="local-type: typedef-55.7">local-type: typedef-55.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.7" title="local-type: typedef-57.7">local-type: typedef-57.7</a>
                       </em>
                     </p>
                   </td>
@@ -92499,7 +92499,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.2" title="local-type: typedef-51.2">local-type: typedef-51.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.2" title="local-type: typedef-50.2">local-type: typedef-50.2</a>
                       </em>
                     </p>
                   </td>
@@ -92520,7 +92520,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.3" title="local-type: typedef-51.3">local-type: typedef-51.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.3" title="local-type: typedef-50.3">local-type: typedef-50.3</a>
                       </em>
                     </p>
                   </td>
@@ -92541,7 +92541,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.4" title="local-type: typedef-51.4">local-type: typedef-51.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.4" title="local-type: typedef-50.4">local-type: typedef-50.4</a>
                       </em>
                     </p>
                   </td>
@@ -92569,7 +92569,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-41.1" title="local-type: typedef-41.1">local-type: typedef-41.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-61.1" title="local-type: typedef-61.1">local-type: typedef-61.1</a>
                       </em>
                     </p>
                   </td>
@@ -93284,7 +93284,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-41.2" title="local-type: typedef-41.2">local-type: typedef-41.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-61.2" title="local-type: typedef-61.2">local-type: typedef-61.2</a>
                       </em>
                     </p>
                   </td>
@@ -95319,8 +95319,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-55.6">
-          <h3>13.37. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-55.6)</code>
+        <div class="sect2" id="local-type.typedef-57.6">
+          <h3>13.37. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-57.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -95340,7 +95340,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-55.6)</code>
+                      <code>  (typedef-57.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -95382,8 +95382,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-55.7">
-          <h3>13.38. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/JourneyParts#complexType (typedef-55.7)</code>
+        <div class="sect2" id="local-type.typedef-57.7">
+          <h3>13.38. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/JourneyParts#complexType (typedef-57.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -95403,7 +95403,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-55.7)</code>
+                      <code>  (typedef-57.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -95445,8 +95445,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.2">
-          <h3>13.39. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-51.2)</code>
+        <div class="sect2" id="local-type.typedef-50.2">
+          <h3>13.39. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-50.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -95466,7 +95466,7 @@
                       <br/>
                       <code>  /TrainElements #complexType</code>
                       <br/>
-                      <code>  (typedef-51.2)</code>
+                      <code>  (typedef-50.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -95553,8 +95553,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.3">
-          <h3>13.40. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-51.3)</code>
+        <div class="sect2" id="local-type.typedef-50.3">
+          <h3>13.40. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-50.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -95574,7 +95574,7 @@
                       <br/>
                       <code>  /Trains #complexType</code>
                       <br/>
-                      <code>  (typedef-51.3)</code>
+                      <code>  (typedef-50.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -95661,8 +95661,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.4">
-          <h3>13.41. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-51.4)</code>
+        <div class="sect2" id="local-type.typedef-50.4">
+          <h3>13.41. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-50.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -95682,7 +95682,7 @@
                       <br/>
                       <code>  /CompoundTrains #complexType</code>
                       <br/>
-                      <code>  (typedef-51.4)</code>
+                      <code>  (typedef-50.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -95769,8 +95769,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-41.1">
-          <h3>13.42. The complex type <code>complexType[siri:DatedVehicleJourneyStructure]/DatedCalls#complexType (typedef-41.1)</code>
+        <div class="sect2" id="local-type.typedef-61.1">
+          <h3>13.42. The complex type <code>complexType[siri:DatedVehicleJourneyStructure]/DatedCalls#complexType (typedef-61.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -95790,7 +95790,7 @@
                       <br/>
                       <code>  /DatedCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-41.1)</code>
+                      <code>  (typedef-61.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -95833,8 +95833,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-41.2">
-          <h3>13.43. The complex type <code>complexType[siri:RemovedDatedVehicleJourneyStructure]/TrainNumbers#complexType (typedef-41.2)</code>
+        <div class="sect2" id="local-type.typedef-61.2">
+          <h3>13.43. The complex type <code>complexType[siri:RemovedDatedVehicleJourneyStructure]/TrainNumbers#complexType (typedef-61.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -95854,7 +95854,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-41.2)</code>
+                      <code>  (typedef-61.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -101250,7 +101250,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-55.4" title="local-type: typedef-55.4">local-type: typedef-55.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.4" title="local-type: typedef-57.4">local-type: typedef-57.4</a>
                       </em>
                     </p>
                   </td>
@@ -101271,7 +101271,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-55.5" title="local-type: typedef-55.5">local-type: typedef-55.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.5" title="local-type: typedef-57.5">local-type: typedef-57.5</a>
                       </em>
                     </p>
                   </td>
@@ -101295,7 +101295,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.2" title="local-type: typedef-51.2">local-type: typedef-51.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.2" title="local-type: typedef-50.2">local-type: typedef-50.2</a>
                       </em>
                     </p>
                   </td>
@@ -101316,7 +101316,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.3" title="local-type: typedef-51.3">local-type: typedef-51.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.3" title="local-type: typedef-50.3">local-type: typedef-50.3</a>
                       </em>
                     </p>
                   </td>
@@ -101337,7 +101337,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.4" title="local-type: typedef-51.4">local-type: typedef-51.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.4" title="local-type: typedef-50.4">local-type: typedef-50.4</a>
                       </em>
                     </p>
                   </td>
@@ -101361,7 +101361,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-56.1" title="local-type: typedef-56.1">local-type: typedef-56.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-66.1" title="local-type: typedef-66.1">local-type: typedef-66.1</a>
                       </em>
                     </p>
                   </td>
@@ -101385,7 +101385,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-56.2" title="local-type: typedef-56.2">local-type: typedef-56.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-66.2" title="local-type: typedef-66.2">local-type: typedef-66.2</a>
                       </em>
                     </p>
                   </td>
@@ -102746,8 +102746,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-55.4">
-          <h3>14.16. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-55.4)</code>
+        <div class="sect2" id="local-type.typedef-57.4">
+          <h3>14.16. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-57.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -102767,7 +102767,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-55.4)</code>
+                      <code>  (typedef-57.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -102809,8 +102809,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-55.5">
-          <h3>14.17. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-55.5)</code>
+        <div class="sect2" id="local-type.typedef-57.5">
+          <h3>14.17. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-57.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -102830,7 +102830,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-55.5)</code>
+                      <code>  (typedef-57.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -102872,8 +102872,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.2">
-          <h3>14.18. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-51.2)</code>
+        <div class="sect2" id="local-type.typedef-50.2">
+          <h3>14.18. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-50.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -102893,7 +102893,7 @@
                       <br/>
                       <code>  /TrainElements #complexType</code>
                       <br/>
-                      <code>  (typedef-51.2)</code>
+                      <code>  (typedef-50.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -102980,8 +102980,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.3">
-          <h3>14.19. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-51.3)</code>
+        <div class="sect2" id="local-type.typedef-50.3">
+          <h3>14.19. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-50.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -103001,7 +103001,7 @@
                       <br/>
                       <code>  /Trains #complexType</code>
                       <br/>
-                      <code>  (typedef-51.3)</code>
+                      <code>  (typedef-50.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -103088,8 +103088,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.4">
-          <h3>14.20. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-51.4)</code>
+        <div class="sect2" id="local-type.typedef-50.4">
+          <h3>14.20. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-50.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -103109,7 +103109,7 @@
                       <br/>
                       <code>  /CompoundTrains #complexType</code>
                       <br/>
-                      <code>  (typedef-51.4)</code>
+                      <code>  (typedef-50.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -103196,8 +103196,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-56.1">
-          <h3>14.21. The complex type <code>complexType[siri:EstimatedVehicleJourneyStructure]/RecordedCalls#complexType (typedef-56.1)</code>
+        <div class="sect2" id="local-type.typedef-66.1">
+          <h3>14.21. The complex type <code>complexType[siri:EstimatedVehicleJourneyStructure]/RecordedCalls#complexType (typedef-66.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -103217,7 +103217,7 @@
                       <br/>
                       <code>  /RecordedCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-56.1)</code>
+                      <code>  (typedef-66.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -103260,8 +103260,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-56.2">
-          <h3>14.22. The complex type <code>complexType[siri:EstimatedVehicleJourneyStructure]/EstimatedCalls#complexType (typedef-56.2)</code>
+        <div class="sect2" id="local-type.typedef-66.2">
+          <h3>14.22. The complex type <code>complexType[siri:EstimatedVehicleJourneyStructure]/EstimatedCalls#complexType (typedef-66.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -103281,7 +103281,7 @@
                       <br/>
                       <code>  /EstimatedCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-56.2)</code>
+                      <code>  (typedef-66.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -108414,7 +108414,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-39.2" title="local-type: typedef-39.2">local-type: typedef-39.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-59.2" title="local-type: typedef-59.2">local-type: typedef-59.2</a>
                       </em>
                     </p>
                   </td>
@@ -108435,7 +108435,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-39.3" title="local-type: typedef-39.3">local-type: typedef-39.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-59.3" title="local-type: typedef-59.3">local-type: typedef-59.3</a>
                       </em>
                     </p>
                   </td>
@@ -109132,7 +109132,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-39.6" title="local-type: typedef-39.6">local-type: typedef-39.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-59.6" title="local-type: typedef-59.6">local-type: typedef-59.6</a>
                       </em>
                     </p>
                   </td>
@@ -109416,7 +109416,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-39.5" title="local-type: typedef-39.5">local-type: typedef-39.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-59.5" title="local-type: typedef-59.5">local-type: typedef-59.5</a>
                       </em>
                     </p>
                   </td>
@@ -110351,7 +110351,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-39.1" title="local-type: typedef-39.1">local-type: typedef-39.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-59.1" title="local-type: typedef-59.1">local-type: typedef-59.1</a>
                       </em>
                     </p>
                   </td>
@@ -110471,7 +110471,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-39.2" title="local-type: typedef-39.2">local-type: typedef-39.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-59.2" title="local-type: typedef-59.2">local-type: typedef-59.2</a>
                       </em>
                     </p>
                   </td>
@@ -110492,7 +110492,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-39.3" title="local-type: typedef-39.3">local-type: typedef-39.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-59.3" title="local-type: typedef-59.3">local-type: typedef-59.3</a>
                       </em>
                     </p>
                   </td>
@@ -110903,7 +110903,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-39.4" title="local-type: typedef-39.4">local-type: typedef-39.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-59.4" title="local-type: typedef-59.4">local-type: typedef-59.4</a>
                       </em>
                     </p>
                   </td>
@@ -111410,8 +111410,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-39.2">
-          <h3>16.32. The complex type <code>group[siri:FacilityAccessibilityGroup]/Limitations#complexType (typedef-39.2)</code>
+        <div class="sect2" id="local-type.typedef-59.2">
+          <h3>16.32. The complex type <code>group[siri:FacilityAccessibilityGroup]/Limitations#complexType (typedef-59.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -111431,7 +111431,7 @@
                       <br/>
                       <code>  /Limitations #complexType</code>
                       <br/>
-                      <code>  (typedef-39.2)</code>
+                      <code>  (typedef-59.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -111587,8 +111587,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-39.3">
-          <h3>16.33. The complex type <code>group[siri:FacilityAccessibilityGroup]/Suitabilities#complexType (typedef-39.3)</code>
+        <div class="sect2" id="local-type.typedef-59.3">
+          <h3>16.33. The complex type <code>group[siri:FacilityAccessibilityGroup]/Suitabilities#complexType (typedef-59.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -111608,7 +111608,7 @@
                       <br/>
                       <code>  /Suitabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-39.3)</code>
+                      <code>  (typedef-59.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -111650,8 +111650,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-39.6">
-          <h3>16.34. The complex type <code>complexType[siri:EquipmentAvailabilityStructure]/EquipmentFeatures#complexType (typedef-39.6)</code>
+        <div class="sect2" id="local-type.typedef-59.6">
+          <h3>16.34. The complex type <code>complexType[siri:EquipmentAvailabilityStructure]/EquipmentFeatures#complexType (typedef-59.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -111671,7 +111671,7 @@
                       <br/>
                       <code>  /EquipmentFeatures #complexType</code>
                       <br/>
-                      <code>  (typedef-39.6)</code>
+                      <code>  (typedef-59.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -111713,8 +111713,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-39.5">
-          <h3>16.35. The complex type <code>complexType[siri:FacilityConditionStructure]/MonitoredCounting#complexType (typedef-39.5)</code>
+        <div class="sect2" id="local-type.typedef-59.5">
+          <h3>16.35. The complex type <code>complexType[siri:FacilityConditionStructure]/MonitoredCounting#complexType (typedef-59.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -111734,7 +111734,7 @@
                       <br/>
                       <code>  /MonitoredCounting #complexType</code>
                       <br/>
-                      <code>  (typedef-39.5)</code>
+                      <code>  (typedef-59.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -111990,7 +111990,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-39.4" title="local-type: typedef-39.4">local-type: typedef-39.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-59.4" title="local-type: typedef-59.4">local-type: typedef-59.4</a>
                       </em>
                     </p>
                   </td>
@@ -112027,8 +112027,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-39.4">
-          <h3>16.36. The complex type <code>complexType[siri:MonitoredCountingStructure]/CountedItemsIdList#complexType (typedef-39.4)</code>
+        <div class="sect2" id="local-type.typedef-59.4">
+          <h3>16.36. The complex type <code>complexType[siri:MonitoredCountingStructure]/CountedItemsIdList#complexType (typedef-59.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -112048,7 +112048,7 @@
                       <br/>
                       <code>  /CountedItemsIdList #complexType</code>
                       <br/>
-                      <code>  (typedef-39.4)</code>
+                      <code>  (typedef-59.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -112091,8 +112091,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-39.1">
-          <h3>16.37. The complex type <code>complexType[siri:FacilityStructure]/Features#complexType (typedef-39.1)</code>
+        <div class="sect2" id="local-type.typedef-59.1">
+          <h3>16.37. The complex type <code>complexType[siri:FacilityStructure]/Features#complexType (typedef-59.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -112112,7 +112112,7 @@
                       <br/>
                       <code>  /Features #complexType</code>
                       <br/>
-                      <code>  (typedef-39.1)</code>
+                      <code>  (typedef-59.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -112154,8 +112154,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-39.2">
-          <h3>16.38. The complex type <code>group[siri:FacilityAccessibilityGroup]/Limitations#complexType (typedef-39.2)</code>
+        <div class="sect2" id="local-type.typedef-59.2">
+          <h3>16.38. The complex type <code>group[siri:FacilityAccessibilityGroup]/Limitations#complexType (typedef-59.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -112175,7 +112175,7 @@
                       <br/>
                       <code>  /Limitations #complexType</code>
                       <br/>
-                      <code>  (typedef-39.2)</code>
+                      <code>  (typedef-59.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -112331,8 +112331,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-39.3">
-          <h3>16.39. The complex type <code>group[siri:FacilityAccessibilityGroup]/Suitabilities#complexType (typedef-39.3)</code>
+        <div class="sect2" id="local-type.typedef-59.3">
+          <h3>16.39. The complex type <code>group[siri:FacilityAccessibilityGroup]/Suitabilities#complexType (typedef-59.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -112352,7 +112352,7 @@
                       <br/>
                       <code>  /Suitabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-39.3)</code>
+                      <code>  (typedef-59.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -112394,8 +112394,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-39.4">
-          <h3>16.40. The complex type <code>complexType[siri:MonitoredCountingStructure]/CountedItemsIdList#complexType (typedef-39.4)</code>
+        <div class="sect2" id="local-type.typedef-59.4">
+          <h3>16.40. The complex type <code>complexType[siri:MonitoredCountingStructure]/CountedItemsIdList#complexType (typedef-59.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -112415,7 +112415,7 @@
                       <br/>
                       <code>  /CountedItemsIdList #complexType</code>
                       <br/>
-                      <code>  (typedef-39.4)</code>
+                      <code>  (typedef-59.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -113862,12 +113862,12 @@
               <tbody>
                 <tr>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-12.1" class="tableblock">
+                    <p id="local-type.typedef-24.1" class="tableblock">
                       <code>attribute[lang]</code>
                       <br/>
                       <code>  #simpleType</code>
                       <br/>
-                      <code>  (typedef-12.1)</code>
+                      <code>  (typedef-24.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -117524,7 +117524,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.2" title="local-type: typedef-51.2">local-type: typedef-51.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.2" title="local-type: typedef-50.2">local-type: typedef-50.2</a>
                       </em>
                     </p>
                   </td>
@@ -117545,7 +117545,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.3" title="local-type: typedef-51.3">local-type: typedef-51.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.3" title="local-type: typedef-50.3">local-type: typedef-50.3</a>
                       </em>
                     </p>
                   </td>
@@ -117566,7 +117566,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.4" title="local-type: typedef-51.4">local-type: typedef-51.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.4" title="local-type: typedef-50.4">local-type: typedef-50.4</a>
                       </em>
                     </p>
                   </td>
@@ -117784,7 +117784,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.1" title="local-type: typedef-51.1">local-type: typedef-51.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.1" title="local-type: typedef-50.1">local-type: typedef-50.1</a>
                       </em>
                     </p>
                   </td>
@@ -121362,7 +121362,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.5" title="local-type: typedef-51.5">local-type: typedef-51.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.5" title="local-type: typedef-50.5">local-type: typedef-50.5</a>
                       </em>
                     </p>
                   </td>
@@ -121743,7 +121743,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.7" title="local-type: typedef-51.7">local-type: typedef-51.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.7" title="local-type: typedef-50.7">local-type: typedef-50.7</a>
                       </em>
                     </p>
                   </td>
@@ -122896,7 +122896,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.9" title="local-type: typedef-51.9">local-type: typedef-51.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.9" title="local-type: typedef-50.9">local-type: typedef-50.9</a>
                       </em>
                     </p>
                   </td>
@@ -123074,7 +123074,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.8" title="local-type: typedef-51.8">local-type: typedef-51.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.8" title="local-type: typedef-50.8">local-type: typedef-50.8</a>
                       </em>
                     </p>
                   </td>
@@ -123211,7 +123211,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.9" title="local-type: typedef-51.9">local-type: typedef-51.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.9" title="local-type: typedef-50.9">local-type: typedef-50.9</a>
                       </em>
                     </p>
                   </td>
@@ -123861,7 +123861,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.9" title="local-type: typedef-51.9">local-type: typedef-51.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.9" title="local-type: typedef-50.9">local-type: typedef-50.9</a>
                       </em>
                     </p>
                   </td>
@@ -124039,7 +124039,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.8" title="local-type: typedef-51.8">local-type: typedef-51.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.8" title="local-type: typedef-50.8">local-type: typedef-50.8</a>
                       </em>
                     </p>
                   </td>
@@ -124063,7 +124063,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.6" title="local-type: typedef-51.6">local-type: typedef-51.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.6" title="local-type: typedef-50.6">local-type: typedef-50.6</a>
                       </em>
                     </p>
                   </td>
@@ -125224,7 +125224,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.1" title="local-type: typedef-51.1">local-type: typedef-51.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.1" title="local-type: typedef-50.1">local-type: typedef-50.1</a>
                       </em>
                     </p>
                   </td>
@@ -128243,7 +128243,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.1" title="local-type: typedef-51.1">local-type: typedef-51.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.1" title="local-type: typedef-50.1">local-type: typedef-50.1</a>
                       </em>
                     </p>
                   </td>
@@ -129434,7 +129434,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.9" title="local-type: typedef-51.9">local-type: typedef-51.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.9" title="local-type: typedef-50.9">local-type: typedef-50.9</a>
                       </em>
                     </p>
                   </td>
@@ -129612,7 +129612,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.8" title="local-type: typedef-51.8">local-type: typedef-51.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.8" title="local-type: typedef-50.8">local-type: typedef-50.8</a>
                       </em>
                     </p>
                   </td>
@@ -130045,7 +130045,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.7" title="local-type: typedef-51.7">local-type: typedef-51.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.7" title="local-type: typedef-50.7">local-type: typedef-50.7</a>
                       </em>
                     </p>
                   </td>
@@ -130293,7 +130293,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.9" title="local-type: typedef-51.9">local-type: typedef-51.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.9" title="local-type: typedef-50.9">local-type: typedef-50.9</a>
                       </em>
                     </p>
                   </td>
@@ -130471,7 +130471,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.8" title="local-type: typedef-51.8">local-type: typedef-51.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.8" title="local-type: typedef-50.8">local-type: typedef-50.8</a>
                       </em>
                     </p>
                   </td>
@@ -130537,7 +130537,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.5" title="local-type: typedef-51.5">local-type: typedef-51.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.5" title="local-type: typedef-50.5">local-type: typedef-50.5</a>
                       </em>
                     </p>
                   </td>
@@ -131391,8 +131391,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.2">
-          <h3>19.124. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-51.2)</code>
+        <div class="sect2" id="local-type.typedef-50.2">
+          <h3>19.124. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-50.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -131412,7 +131412,7 @@
                       <br/>
                       <code>  /TrainElements #complexType</code>
                       <br/>
-                      <code>  (typedef-51.2)</code>
+                      <code>  (typedef-50.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -131499,8 +131499,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.3">
-          <h3>19.125. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-51.3)</code>
+        <div class="sect2" id="local-type.typedef-50.3">
+          <h3>19.125. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-50.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -131520,7 +131520,7 @@
                       <br/>
                       <code>  /Trains #complexType</code>
                       <br/>
-                      <code>  (typedef-51.3)</code>
+                      <code>  (typedef-50.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -131607,8 +131607,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.4">
-          <h3>19.126. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-51.4)</code>
+        <div class="sect2" id="local-type.typedef-50.4">
+          <h3>19.126. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-50.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -131628,7 +131628,7 @@
                       <br/>
                       <code>  /CompoundTrains #complexType</code>
                       <br/>
-                      <code>  (typedef-51.4)</code>
+                      <code>  (typedef-50.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -131715,8 +131715,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.1">
-          <h3>19.127. The complex type <code>group[siri:JourneyRelationInfoGroup]/JourneyParts#complexType (typedef-51.1)</code>
+        <div class="sect2" id="local-type.typedef-50.1">
+          <h3>19.127. The complex type <code>group[siri:JourneyRelationInfoGroup]/JourneyParts#complexType (typedef-50.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -131736,7 +131736,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-51.1)</code>
+                      <code>  (typedef-50.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -131778,8 +131778,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.5">
-          <h3>19.128. The complex type <code>group[siri:TrainGroup]/TrainComponents#complexType (typedef-51.5)</code>
+        <div class="sect2" id="local-type.typedef-50.5">
+          <h3>19.128. The complex type <code>group[siri:TrainGroup]/TrainComponents#complexType (typedef-50.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -131799,7 +131799,7 @@
                       <br/>
                       <code>  /TrainComponents #complexType</code>
                       <br/>
-                      <code>  (typedef-51.5)</code>
+                      <code>  (typedef-50.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -131886,8 +131886,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.7">
-          <h3>19.129. The complex type <code>group[siri:TrainInCompoundTrainGroup]/Passages#complexType (typedef-51.7)</code>
+        <div class="sect2" id="local-type.typedef-50.7">
+          <h3>19.129. The complex type <code>group[siri:TrainInCompoundTrainGroup]/Passages#complexType (typedef-50.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -131907,7 +131907,7 @@
                       <br/>
                       <code>  /Passages #complexType</code>
                       <br/>
-                      <code>  (typedef-51.7)</code>
+                      <code>  (typedef-50.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -131949,8 +131949,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.9">
-          <h3>19.130. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-51.9)</code>
+        <div class="sect2" id="local-type.typedef-50.9">
+          <h3>19.130. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-50.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -131970,7 +131970,7 @@
                       <br/>
                       <code>  /MaximumPassengerCapacities #complexType</code>
                       <br/>
-                      <code>  (typedef-51.9)</code>
+                      <code>  (typedef-50.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -132012,8 +132012,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.8">
-          <h3>19.131. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-51.8)</code>
+        <div class="sect2" id="local-type.typedef-50.8">
+          <h3>19.131. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-50.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -132033,7 +132033,7 @@
                       <br/>
                       <code>  /Facilities #complexType</code>
                       <br/>
-                      <code>  (typedef-51.8)</code>
+                      <code>  (typedef-50.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -132153,8 +132153,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.9">
-          <h3>19.132. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-51.9)</code>
+        <div class="sect2" id="local-type.typedef-50.9">
+          <h3>19.132. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-50.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -132174,7 +132174,7 @@
                       <br/>
                       <code>  /MaximumPassengerCapacities #complexType</code>
                       <br/>
-                      <code>  (typedef-51.9)</code>
+                      <code>  (typedef-50.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -132216,8 +132216,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.9">
-          <h3>19.133. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-51.9)</code>
+        <div class="sect2" id="local-type.typedef-50.9">
+          <h3>19.133. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-50.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -132237,7 +132237,7 @@
                       <br/>
                       <code>  /MaximumPassengerCapacities #complexType</code>
                       <br/>
-                      <code>  (typedef-51.9)</code>
+                      <code>  (typedef-50.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -132279,8 +132279,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.8">
-          <h3>19.134. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-51.8)</code>
+        <div class="sect2" id="local-type.typedef-50.8">
+          <h3>19.134. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-50.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -132300,7 +132300,7 @@
                       <br/>
                       <code>  /Facilities #complexType</code>
                       <br/>
-                      <code>  (typedef-51.8)</code>
+                      <code>  (typedef-50.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -132420,8 +132420,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.6">
-          <h3>19.135. The complex type <code>complexType[siri:CompoundTrainStructure]/TrainsInCompoundTrain#complexType (typedef-51.6)</code>
+        <div class="sect2" id="local-type.typedef-50.6">
+          <h3>19.135. The complex type <code>complexType[siri:CompoundTrainStructure]/TrainsInCompoundTrain#complexType (typedef-50.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -132441,7 +132441,7 @@
                       <br/>
                       <code>  /TrainsInCompoundTrain #complexType</code>
                       <br/>
-                      <code>  (typedef-51.6)</code>
+                      <code>  (typedef-50.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -132528,8 +132528,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.1">
-          <h3>19.136. The complex type <code>group[siri:JourneyRelationInfoGroup]/JourneyParts#complexType (typedef-51.1)</code>
+        <div class="sect2" id="local-type.typedef-50.1">
+          <h3>19.136. The complex type <code>group[siri:JourneyRelationInfoGroup]/JourneyParts#complexType (typedef-50.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -132549,7 +132549,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-51.1)</code>
+                      <code>  (typedef-50.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -132591,8 +132591,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.1">
-          <h3>19.137. The complex type <code>group[siri:JourneyRelationInfoGroup]/JourneyParts#complexType (typedef-51.1)</code>
+        <div class="sect2" id="local-type.typedef-50.1">
+          <h3>19.137. The complex type <code>group[siri:JourneyRelationInfoGroup]/JourneyParts#complexType (typedef-50.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -132612,7 +132612,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-51.1)</code>
+                      <code>  (typedef-50.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -132654,8 +132654,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.9">
-          <h3>19.138. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-51.9)</code>
+        <div class="sect2" id="local-type.typedef-50.9">
+          <h3>19.138. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-50.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -132675,7 +132675,7 @@
                       <br/>
                       <code>  /MaximumPassengerCapacities #complexType</code>
                       <br/>
-                      <code>  (typedef-51.9)</code>
+                      <code>  (typedef-50.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -132717,8 +132717,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.8">
-          <h3>19.139. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-51.8)</code>
+        <div class="sect2" id="local-type.typedef-50.8">
+          <h3>19.139. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-50.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -132738,7 +132738,7 @@
                       <br/>
                       <code>  /Facilities #complexType</code>
                       <br/>
-                      <code>  (typedef-51.8)</code>
+                      <code>  (typedef-50.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -132858,8 +132858,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.7">
-          <h3>19.140. The complex type <code>group[siri:TrainInCompoundTrainGroup]/Passages#complexType (typedef-51.7)</code>
+        <div class="sect2" id="local-type.typedef-50.7">
+          <h3>19.140. The complex type <code>group[siri:TrainInCompoundTrainGroup]/Passages#complexType (typedef-50.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -132879,7 +132879,7 @@
                       <br/>
                       <code>  /Passages #complexType</code>
                       <br/>
-                      <code>  (typedef-51.7)</code>
+                      <code>  (typedef-50.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -132921,8 +132921,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.9">
-          <h3>19.141. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-51.9)</code>
+        <div class="sect2" id="local-type.typedef-50.9">
+          <h3>19.141. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-50.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -132942,7 +132942,7 @@
                       <br/>
                       <code>  /MaximumPassengerCapacities #complexType</code>
                       <br/>
-                      <code>  (typedef-51.9)</code>
+                      <code>  (typedef-50.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -132984,8 +132984,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.8">
-          <h3>19.142. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-51.8)</code>
+        <div class="sect2" id="local-type.typedef-50.8">
+          <h3>19.142. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-50.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -133005,7 +133005,7 @@
                       <br/>
                       <code>  /Facilities #complexType</code>
                       <br/>
-                      <code>  (typedef-51.8)</code>
+                      <code>  (typedef-50.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -133125,8 +133125,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.5">
-          <h3>19.143. The complex type <code>group[siri:TrainGroup]/TrainComponents#complexType (typedef-51.5)</code>
+        <div class="sect2" id="local-type.typedef-50.5">
+          <h3>19.143. The complex type <code>group[siri:TrainGroup]/TrainComponents#complexType (typedef-50.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -133146,7 +133146,7 @@
                       <br/>
                       <code>  /TrainComponents #complexType</code>
                       <br/>
-                      <code>  (typedef-51.5)</code>
+                      <code>  (typedef-50.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -138263,7 +138263,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-13.1" title="local-type: typedef-13.1">local-type: typedef-13.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
                       </em>
                     </p>
                   </td>
@@ -138297,7 +138297,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-43.2" title="local-type: typedef-43.2">local-type: typedef-43.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-56.2" title="local-type: typedef-56.2">local-type: typedef-56.2</a>
                       </em>
                     </p>
                   </td>
@@ -138326,7 +138326,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-43.1" title="local-type: typedef-43.1">local-type: typedef-43.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-56.1" title="local-type: typedef-56.1">local-type: typedef-56.1</a>
                       </em>
                     </p>
                   </td>
@@ -138355,7 +138355,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-43.3" title="local-type: typedef-43.3">local-type: typedef-43.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-56.3" title="local-type: typedef-56.3">local-type: typedef-56.3</a>
                       </em>
                     </p>
                   </td>
@@ -138907,8 +138907,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-43.3">
-          <h3>21.31. The complex type <code>element[siri:ConnectionLinkPermissions]#complexType (typedef-43.3)</code>
+        <div class="sect2" id="local-type.typedef-56.3">
+          <h3>21.31. The complex type <code>element[siri:ConnectionLinkPermissions]#complexType (typedef-56.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -138928,7 +138928,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-43.3)</code>
+                      <code>  (typedef-56.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -139013,8 +139013,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-43.1">
-          <h3>21.32. The complex type <code>element[siri:LinePermissions]#complexType (typedef-43.1)</code>
+        <div class="sect2" id="local-type.typedef-56.1">
+          <h3>21.32. The complex type <code>element[siri:LinePermissions]#complexType (typedef-56.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -139034,7 +139034,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-43.1)</code>
+                      <code>  (typedef-56.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -139119,8 +139119,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-43.2">
-          <h3>21.33. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-43.2)</code>
+        <div class="sect2" id="local-type.typedef-56.2">
+          <h3>21.33. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-56.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -139140,7 +139140,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-43.2)</code>
+                      <code>  (typedef-56.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -139225,8 +139225,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-13.1">
-          <h3>21.34. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-13.1)</code>
+        <div class="sect2" id="local-type.typedef-36.1">
+          <h3>21.34. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-36.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -139246,7 +139246,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-13.1)</code>
+                      <code>  (typedef-36.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -139314,8 +139314,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-43.2">
-          <h3>21.35. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-43.2)</code>
+        <div class="sect2" id="local-type.typedef-56.2">
+          <h3>21.35. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-56.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -139335,7 +139335,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-43.2)</code>
+                      <code>  (typedef-56.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -139420,8 +139420,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-43.1">
-          <h3>21.36. The complex type <code>element[siri:LinePermissions]#complexType (typedef-43.1)</code>
+        <div class="sect2" id="local-type.typedef-56.1">
+          <h3>21.36. The complex type <code>element[siri:LinePermissions]#complexType (typedef-56.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -139441,7 +139441,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-43.1)</code>
+                      <code>  (typedef-56.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -139526,8 +139526,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-43.3">
-          <h3>21.37. The complex type <code>element[siri:ConnectionLinkPermissions]#complexType (typedef-43.3)</code>
+        <div class="sect2" id="local-type.typedef-56.3">
+          <h3>21.37. The complex type <code>element[siri:ConnectionLinkPermissions]#complexType (typedef-56.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -139547,7 +139547,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-43.3)</code>
+                      <code>  (typedef-56.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -145760,7 +145760,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-55.6" title="local-type: typedef-55.6">local-type: typedef-55.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.6" title="local-type: typedef-57.6">local-type: typedef-57.6</a>
                       </em>
                     </p>
                   </td>
@@ -145781,7 +145781,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-55.7" title="local-type: typedef-55.7">local-type: typedef-55.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.7" title="local-type: typedef-57.7">local-type: typedef-57.7</a>
                       </em>
                     </p>
                   </td>
@@ -145805,7 +145805,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.2" title="local-type: typedef-51.2">local-type: typedef-51.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.2" title="local-type: typedef-50.2">local-type: typedef-50.2</a>
                       </em>
                     </p>
                   </td>
@@ -145826,7 +145826,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.3" title="local-type: typedef-51.3">local-type: typedef-51.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.3" title="local-type: typedef-50.3">local-type: typedef-50.3</a>
                       </em>
                     </p>
                   </td>
@@ -145847,7 +145847,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.4" title="local-type: typedef-51.4">local-type: typedef-51.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.4" title="local-type: typedef-50.4">local-type: typedef-50.4</a>
                       </em>
                     </p>
                   </td>
@@ -148549,7 +148549,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-55.1" title="local-type: typedef-55.1">local-type: typedef-55.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.1" title="local-type: typedef-57.1">local-type: typedef-57.1</a>
                       </em>
                     </p>
                   </td>
@@ -148570,7 +148570,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-55.2" title="local-type: typedef-55.2">local-type: typedef-55.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.2" title="local-type: typedef-57.2">local-type: typedef-57.2</a>
                       </em>
                     </p>
                   </td>
@@ -148591,7 +148591,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-55.3" title="local-type: typedef-55.3">local-type: typedef-55.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.3" title="local-type: typedef-57.3">local-type: typedef-57.3</a>
                       </em>
                     </p>
                   </td>
@@ -149696,7 +149696,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-55.4" title="local-type: typedef-55.4">local-type: typedef-55.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.4" title="local-type: typedef-57.4">local-type: typedef-57.4</a>
                       </em>
                     </p>
                   </td>
@@ -149717,7 +149717,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-55.5" title="local-type: typedef-55.5">local-type: typedef-55.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.5" title="local-type: typedef-57.5">local-type: typedef-57.5</a>
                       </em>
                     </p>
                   </td>
@@ -149741,7 +149741,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.2" title="local-type: typedef-51.2">local-type: typedef-51.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.2" title="local-type: typedef-50.2">local-type: typedef-50.2</a>
                       </em>
                     </p>
                   </td>
@@ -149762,7 +149762,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.3" title="local-type: typedef-51.3">local-type: typedef-51.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.3" title="local-type: typedef-50.3">local-type: typedef-50.3</a>
                       </em>
                     </p>
                   </td>
@@ -149783,7 +149783,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.4" title="local-type: typedef-51.4">local-type: typedef-51.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.4" title="local-type: typedef-50.4">local-type: typedef-50.4</a>
                       </em>
                     </p>
                   </td>
@@ -153084,7 +153084,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-55.4" title="local-type: typedef-55.4">local-type: typedef-55.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.4" title="local-type: typedef-57.4">local-type: typedef-57.4</a>
                       </em>
                     </p>
                   </td>
@@ -153105,7 +153105,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-55.5" title="local-type: typedef-55.5">local-type: typedef-55.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.5" title="local-type: typedef-57.5">local-type: typedef-57.5</a>
                       </em>
                     </p>
                   </td>
@@ -153129,7 +153129,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.2" title="local-type: typedef-51.2">local-type: typedef-51.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.2" title="local-type: typedef-50.2">local-type: typedef-50.2</a>
                       </em>
                     </p>
                   </td>
@@ -153150,7 +153150,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.3" title="local-type: typedef-51.3">local-type: typedef-51.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.3" title="local-type: typedef-50.3">local-type: typedef-50.3</a>
                       </em>
                     </p>
                   </td>
@@ -153171,7 +153171,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.4" title="local-type: typedef-51.4">local-type: typedef-51.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.4" title="local-type: typedef-50.4">local-type: typedef-50.4</a>
                       </em>
                     </p>
                   </td>
@@ -153833,8 +153833,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-55.6">
-          <h3>23.23. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-55.6)</code>
+        <div class="sect2" id="local-type.typedef-57.6">
+          <h3>23.23. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-57.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -153854,7 +153854,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-55.6)</code>
+                      <code>  (typedef-57.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -153896,8 +153896,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-55.7">
-          <h3>23.24. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/JourneyParts#complexType (typedef-55.7)</code>
+        <div class="sect2" id="local-type.typedef-57.7">
+          <h3>23.24. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/JourneyParts#complexType (typedef-57.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -153917,7 +153917,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-55.7)</code>
+                      <code>  (typedef-57.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -153959,8 +153959,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.2">
-          <h3>23.25. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-51.2)</code>
+        <div class="sect2" id="local-type.typedef-50.2">
+          <h3>23.25. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-50.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -153980,7 +153980,7 @@
                       <br/>
                       <code>  /TrainElements #complexType</code>
                       <br/>
-                      <code>  (typedef-51.2)</code>
+                      <code>  (typedef-50.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -154067,8 +154067,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.3">
-          <h3>23.26. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-51.3)</code>
+        <div class="sect2" id="local-type.typedef-50.3">
+          <h3>23.26. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-50.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -154088,7 +154088,7 @@
                       <br/>
                       <code>  /Trains #complexType</code>
                       <br/>
-                      <code>  (typedef-51.3)</code>
+                      <code>  (typedef-50.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -154175,8 +154175,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.4">
-          <h3>23.27. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-51.4)</code>
+        <div class="sect2" id="local-type.typedef-50.4">
+          <h3>23.27. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-50.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -154196,7 +154196,7 @@
                       <br/>
                       <code>  /CompoundTrains #complexType</code>
                       <br/>
-                      <code>  (typedef-51.4)</code>
+                      <code>  (typedef-50.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -154283,8 +154283,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-55.1">
-          <h3>23.28. The complex type <code>group[siri:ServicePointsGroup]/Origin#complexType (typedef-55.1)</code>
+        <div class="sect2" id="local-type.typedef-57.1">
+          <h3>23.28. The complex type <code>group[siri:ServicePointsGroup]/Origin#complexType (typedef-57.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -154304,7 +154304,7 @@
                       <br/>
                       <code>  /Origin #complexType</code>
                       <br/>
-                      <code>  (typedef-55.1)</code>
+                      <code>  (typedef-57.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -154368,8 +154368,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-55.2">
-          <h3>23.29. The complex type <code>group[siri:ServicePointsGroup]/Via#complexType (typedef-55.2)</code>
+        <div class="sect2" id="local-type.typedef-57.2">
+          <h3>23.29. The complex type <code>group[siri:ServicePointsGroup]/Via#complexType (typedef-57.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -154389,7 +154389,7 @@
                       <br/>
                       <code>  /Via #complexType</code>
                       <br/>
-                      <code>  (typedef-55.2)</code>
+                      <code>  (typedef-57.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -154476,8 +154476,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-55.3">
-          <h3>23.30. The complex type <code>group[siri:ServicePointsGroup]/Destination#complexType (typedef-55.3)</code>
+        <div class="sect2" id="local-type.typedef-57.3">
+          <h3>23.30. The complex type <code>group[siri:ServicePointsGroup]/Destination#complexType (typedef-57.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -154497,7 +154497,7 @@
                       <br/>
                       <code>  /Destination #complexType</code>
                       <br/>
-                      <code>  (typedef-55.3)</code>
+                      <code>  (typedef-57.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -154561,8 +154561,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-55.4">
-          <h3>23.31. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-55.4)</code>
+        <div class="sect2" id="local-type.typedef-57.4">
+          <h3>23.31. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-57.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -154582,7 +154582,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-55.4)</code>
+                      <code>  (typedef-57.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -154624,8 +154624,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-55.5">
-          <h3>23.32. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-55.5)</code>
+        <div class="sect2" id="local-type.typedef-57.5">
+          <h3>23.32. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-57.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -154645,7 +154645,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-55.5)</code>
+                      <code>  (typedef-57.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -154687,8 +154687,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.2">
-          <h3>23.33. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-51.2)</code>
+        <div class="sect2" id="local-type.typedef-50.2">
+          <h3>23.33. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-50.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -154708,7 +154708,7 @@
                       <br/>
                       <code>  /TrainElements #complexType</code>
                       <br/>
-                      <code>  (typedef-51.2)</code>
+                      <code>  (typedef-50.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -154795,8 +154795,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.3">
-          <h3>23.34. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-51.3)</code>
+        <div class="sect2" id="local-type.typedef-50.3">
+          <h3>23.34. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-50.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -154816,7 +154816,7 @@
                       <br/>
                       <code>  /Trains #complexType</code>
                       <br/>
-                      <code>  (typedef-51.3)</code>
+                      <code>  (typedef-50.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -154903,8 +154903,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.4">
-          <h3>23.35. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-51.4)</code>
+        <div class="sect2" id="local-type.typedef-50.4">
+          <h3>23.35. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-50.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -154924,7 +154924,7 @@
                       <br/>
                       <code>  /CompoundTrains #complexType</code>
                       <br/>
-                      <code>  (typedef-51.4)</code>
+                      <code>  (typedef-50.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -155011,8 +155011,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-55.4">
-          <h3>23.36. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-55.4)</code>
+        <div class="sect2" id="local-type.typedef-57.4">
+          <h3>23.36. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-57.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -155032,7 +155032,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-55.4)</code>
+                      <code>  (typedef-57.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -155074,8 +155074,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-55.5">
-          <h3>23.37. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-55.5)</code>
+        <div class="sect2" id="local-type.typedef-57.5">
+          <h3>23.37. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-57.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -155095,7 +155095,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-55.5)</code>
+                      <code>  (typedef-57.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -155137,8 +155137,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.2">
-          <h3>23.38. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-51.2)</code>
+        <div class="sect2" id="local-type.typedef-50.2">
+          <h3>23.38. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-50.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -155158,7 +155158,7 @@
                       <br/>
                       <code>  /TrainElements #complexType</code>
                       <br/>
-                      <code>  (typedef-51.2)</code>
+                      <code>  (typedef-50.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -155245,8 +155245,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.3">
-          <h3>23.39. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-51.3)</code>
+        <div class="sect2" id="local-type.typedef-50.3">
+          <h3>23.39. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-50.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -155266,7 +155266,7 @@
                       <br/>
                       <code>  /Trains #complexType</code>
                       <br/>
-                      <code>  (typedef-51.3)</code>
+                      <code>  (typedef-50.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -155353,8 +155353,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.4">
-          <h3>23.40. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-51.4)</code>
+        <div class="sect2" id="local-type.typedef-50.4">
+          <h3>23.40. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-50.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -155374,7 +155374,7 @@
                       <br/>
                       <code>  /CompoundTrains #complexType</code>
                       <br/>
-                      <code>  (typedef-51.4)</code>
+                      <code>  (typedef-50.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -160002,12 +160002,12 @@
                 </tr>
                 <tr>
                   <td colspan="1" rowspan="2" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-54.3" class="tableblock">
+                    <p id="local-type.typedef-60.3" class="tableblock">
                       <code>group[siri:ClassifierGroup]</code>
                       <br/>
                       <code>  /ScopeType #simpleType</code>
                       <br/>
-                      <code>  (typedef-54.3)</code>
+                      <code>  (typedef-60.3)</code>
                     </p>
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
@@ -160188,12 +160188,12 @@
                 </tr>
                 <tr>
                   <td colspan="1" rowspan="2" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-54.1" class="tableblock">
+                    <p id="local-type.typedef-60.1" class="tableblock">
                       <code>group[siri:StatusGroup]</code>
                       <br/>
                       <code>  /Verification #simpleType</code>
                       <br/>
-                      <code>  (typedef-54.1)</code>
+                      <code>  (typedef-60.1)</code>
                     </p>
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
@@ -160254,12 +160254,12 @@
                 </tr>
                 <tr>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-12.1" class="tableblock">
+                    <p id="local-type.typedef-24.1" class="tableblock">
                       <code>attribute[lang]</code>
                       <br/>
                       <code>  #simpleType</code>
                       <br/>
-                      <code>  (typedef-12.1)</code>
+                      <code>  (typedef-24.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -160866,7 +160866,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-54.3" title="local-type: typedef-54.3">local-type: typedef-54.3</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-60.3" title="local-type: typedef-60.3">local-type: typedef-60.3</a>
                       </em>
                     </p>
                   </td>
@@ -160950,7 +160950,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.4" title="local-type: typedef-54.4">local-type: typedef-54.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.4" title="local-type: typedef-60.4">local-type: typedef-60.4</a>
                       </em>
                     </p>
                   </td>
@@ -161716,7 +161716,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.14" title="local-type: typedef-54.14">local-type: typedef-54.14</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.14" title="local-type: typedef-60.14">local-type: typedef-60.14</a>
                       </em>
                     </p>
                   </td>
@@ -161737,7 +161737,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.16" title="local-type: typedef-54.16">local-type: typedef-54.16</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.16" title="local-type: typedef-60.16">local-type: typedef-60.16</a>
                       </em>
                     </p>
                   </td>
@@ -161890,7 +161890,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-54.1" title="local-type: typedef-54.1">local-type: typedef-54.1</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-60.1" title="local-type: typedef-60.1">local-type: typedef-60.1</a>
                       </em>
                     </p>
                   </td>
@@ -162049,7 +162049,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.2" title="local-type: typedef-54.2">local-type: typedef-54.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.2" title="local-type: typedef-60.2">local-type: typedef-60.2</a>
                       </em>
                     </p>
                   </td>
@@ -162576,7 +162576,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-54.3" title="local-type: typedef-54.3">local-type: typedef-54.3</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-60.3" title="local-type: typedef-60.3">local-type: typedef-60.3</a>
                       </em>
                     </p>
                   </td>
@@ -162660,7 +162660,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.4" title="local-type: typedef-54.4">local-type: typedef-54.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.4" title="local-type: typedef-60.4">local-type: typedef-60.4</a>
                       </em>
                     </p>
                   </td>
@@ -162809,7 +162809,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.14" title="local-type: typedef-54.14">local-type: typedef-54.14</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.14" title="local-type: typedef-60.14">local-type: typedef-60.14</a>
                       </em>
                     </p>
                   </td>
@@ -162830,7 +162830,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.16" title="local-type: typedef-54.16">local-type: typedef-54.16</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.16" title="local-type: typedef-60.16">local-type: typedef-60.16</a>
                       </em>
                     </p>
                   </td>
@@ -163495,7 +163495,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-54.1" title="local-type: typedef-54.1">local-type: typedef-54.1</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-60.1" title="local-type: typedef-60.1">local-type: typedef-60.1</a>
                       </em>
                     </p>
                   </td>
@@ -163654,7 +163654,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.2" title="local-type: typedef-54.2">local-type: typedef-54.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.2" title="local-type: typedef-60.2">local-type: typedef-60.2</a>
                       </em>
                     </p>
                   </td>
@@ -164181,7 +164181,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-54.3" title="local-type: typedef-54.3">local-type: typedef-54.3</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-60.3" title="local-type: typedef-60.3">local-type: typedef-60.3</a>
                       </em>
                     </p>
                   </td>
@@ -164265,7 +164265,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.4" title="local-type: typedef-54.4">local-type: typedef-54.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.4" title="local-type: typedef-60.4">local-type: typedef-60.4</a>
                       </em>
                     </p>
                   </td>
@@ -164414,7 +164414,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.14" title="local-type: typedef-54.14">local-type: typedef-54.14</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.14" title="local-type: typedef-60.14">local-type: typedef-60.14</a>
                       </em>
                     </p>
                   </td>
@@ -164435,7 +164435,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.16" title="local-type: typedef-54.16">local-type: typedef-54.16</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.16" title="local-type: typedef-60.16">local-type: typedef-60.16</a>
                       </em>
                     </p>
                   </td>
@@ -164798,7 +164798,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-54.1" title="local-type: typedef-54.1">local-type: typedef-54.1</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-60.1" title="local-type: typedef-60.1">local-type: typedef-60.1</a>
                       </em>
                     </p>
                   </td>
@@ -164988,7 +164988,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.2" title="local-type: typedef-54.2">local-type: typedef-54.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.2" title="local-type: typedef-60.2">local-type: typedef-60.2</a>
                       </em>
                     </p>
                   </td>
@@ -165488,7 +165488,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.6" title="local-type: typedef-54.6">local-type: typedef-54.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.6" title="local-type: typedef-60.6">local-type: typedef-60.6</a>
                       </em>
                     </p>
                   </td>
@@ -165512,7 +165512,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.7" title="local-type: typedef-54.7">local-type: typedef-54.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.7" title="local-type: typedef-60.7">local-type: typedef-60.7</a>
                       </em>
                     </p>
                   </td>
@@ -165536,7 +165536,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.9" title="local-type: typedef-54.9">local-type: typedef-54.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.9" title="local-type: typedef-60.9">local-type: typedef-60.9</a>
                       </em>
                     </p>
                   </td>
@@ -165560,7 +165560,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.10" title="local-type: typedef-54.10">local-type: typedef-54.10</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.10" title="local-type: typedef-60.10">local-type: typedef-60.10</a>
                       </em>
                     </p>
                   </td>
@@ -165584,7 +165584,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.11" title="local-type: typedef-54.11">local-type: typedef-54.11</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.11" title="local-type: typedef-60.11">local-type: typedef-60.11</a>
                       </em>
                     </p>
                   </td>
@@ -165608,7 +165608,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.12" title="local-type: typedef-54.12">local-type: typedef-54.12</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.12" title="local-type: typedef-60.12">local-type: typedef-60.12</a>
                       </em>
                     </p>
                   </td>
@@ -165632,7 +165632,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.13" title="local-type: typedef-54.13">local-type: typedef-54.13</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.13" title="local-type: typedef-60.13">local-type: typedef-60.13</a>
                       </em>
                     </p>
                   </td>
@@ -167180,7 +167180,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.17" title="local-type: typedef-54.17">local-type: typedef-54.17</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.17" title="local-type: typedef-60.17">local-type: typedef-60.17</a>
                       </em>
                     </p>
                   </td>
@@ -167653,7 +167653,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-54.1" title="local-type: typedef-54.1">local-type: typedef-54.1</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-60.1" title="local-type: typedef-60.1">local-type: typedef-60.1</a>
                       </em>
                     </p>
                   </td>
@@ -167812,7 +167812,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.2" title="local-type: typedef-54.2">local-type: typedef-54.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.2" title="local-type: typedef-60.2">local-type: typedef-60.2</a>
                       </em>
                     </p>
                   </td>
@@ -168339,7 +168339,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-54.3" title="local-type: typedef-54.3">local-type: typedef-54.3</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-60.3" title="local-type: typedef-60.3">local-type: typedef-60.3</a>
                       </em>
                     </p>
                   </td>
@@ -168423,7 +168423,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.4" title="local-type: typedef-54.4">local-type: typedef-54.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.4" title="local-type: typedef-60.4">local-type: typedef-60.4</a>
                       </em>
                     </p>
                   </td>
@@ -168572,7 +168572,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.14" title="local-type: typedef-54.14">local-type: typedef-54.14</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.14" title="local-type: typedef-60.14">local-type: typedef-60.14</a>
                       </em>
                     </p>
                   </td>
@@ -168593,7 +168593,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.16" title="local-type: typedef-54.16">local-type: typedef-54.16</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.16" title="local-type: typedef-60.16">local-type: typedef-60.16</a>
                       </em>
                     </p>
                   </td>
@@ -169315,7 +169315,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-54.1" title="local-type: typedef-54.1">local-type: typedef-54.1</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-60.1" title="local-type: typedef-60.1">local-type: typedef-60.1</a>
                       </em>
                     </p>
                   </td>
@@ -169474,7 +169474,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.2" title="local-type: typedef-54.2">local-type: typedef-54.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.2" title="local-type: typedef-60.2">local-type: typedef-60.2</a>
                       </em>
                     </p>
                   </td>
@@ -170001,7 +170001,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-54.3" title="local-type: typedef-54.3">local-type: typedef-54.3</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-60.3" title="local-type: typedef-60.3">local-type: typedef-60.3</a>
                       </em>
                     </p>
                   </td>
@@ -170085,7 +170085,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.4" title="local-type: typedef-54.4">local-type: typedef-54.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.4" title="local-type: typedef-60.4">local-type: typedef-60.4</a>
                       </em>
                     </p>
                   </td>
@@ -170234,7 +170234,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.14" title="local-type: typedef-54.14">local-type: typedef-54.14</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.14" title="local-type: typedef-60.14">local-type: typedef-60.14</a>
                       </em>
                     </p>
                   </td>
@@ -170255,7 +170255,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.16" title="local-type: typedef-54.16">local-type: typedef-54.16</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.16" title="local-type: typedef-60.16">local-type: typedef-60.16</a>
                       </em>
                     </p>
                   </td>
@@ -171040,8 +171040,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.4">
-          <h3>26.53. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-54.4)</code>
+        <div class="sect2" id="local-type.typedef-60.4">
+          <h3>26.53. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-60.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -171061,7 +171061,7 @@
                       <br/>
                       <code>  /SecondaryReasons #complexType</code>
                       <br/>
-                      <code>  (typedef-54.4)</code>
+                      <code>  (typedef-60.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -171091,7 +171091,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.5" title="local-type: typedef-54.5">local-type: typedef-54.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.5" title="local-type: typedef-60.5">local-type: typedef-60.5</a>
                       </em>
                     </p>
                   </td>
@@ -171103,8 +171103,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.5">
-          <h3>26.54. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-54.5)</code>
+        <div class="sect2" id="local-type.typedef-60.5">
+          <h3>26.54. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-60.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -171124,7 +171124,7 @@
                       <br/>
                       <code>  /SecondaryReasons/Reason #complexType</code>
                       <br/>
-                      <code>  (typedef-54.5)</code>
+                      <code>  (typedef-60.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -171532,8 +171532,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.14">
-          <h3>26.55. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-54.14)</code>
+        <div class="sect2" id="local-type.typedef-60.14">
+          <h3>26.55. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-60.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -171553,7 +171553,7 @@
                       <br/>
                       <code>  /Images #complexType</code>
                       <br/>
-                      <code>  (typedef-54.14)</code>
+                      <code>  (typedef-60.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -171583,7 +171583,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.15" title="local-type: typedef-54.15">local-type: typedef-54.15</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.15" title="local-type: typedef-60.15">local-type: typedef-60.15</a>
                       </em>
                     </p>
                   </td>
@@ -171595,8 +171595,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.15">
-          <h3>26.56. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-54.15)</code>
+        <div class="sect2" id="local-type.typedef-60.15">
+          <h3>26.56. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-60.15)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -171616,7 +171616,7 @@
                       <br/>
                       <code>  /Images/Image #complexType</code>
                       <br/>
-                      <code>  (typedef-54.15)</code>
+                      <code>  (typedef-60.15)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -171731,8 +171731,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.16">
-          <h3>26.57. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-54.16)</code>
+        <div class="sect2" id="local-type.typedef-60.16">
+          <h3>26.57. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-60.16)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -171752,7 +171752,7 @@
                       <br/>
                       <code>  /InfoLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-54.16)</code>
+                      <code>  (typedef-60.16)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -171794,8 +171794,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.2">
-          <h3>26.58. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-54.2)</code>
+        <div class="sect2" id="local-type.typedef-60.2">
+          <h3>26.58. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-60.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -171815,7 +171815,7 @@
                       <br/>
                       <code>  /Repetitions #complexType</code>
                       <br/>
-                      <code>  (typedef-54.2)</code>
+                      <code>  (typedef-60.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -171859,8 +171859,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.4">
-          <h3>26.59. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-54.4)</code>
+        <div class="sect2" id="local-type.typedef-60.4">
+          <h3>26.59. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-60.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -171880,7 +171880,7 @@
                       <br/>
                       <code>  /SecondaryReasons #complexType</code>
                       <br/>
-                      <code>  (typedef-54.4)</code>
+                      <code>  (typedef-60.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -171910,7 +171910,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.5" title="local-type: typedef-54.5">local-type: typedef-54.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.5" title="local-type: typedef-60.5">local-type: typedef-60.5</a>
                       </em>
                     </p>
                   </td>
@@ -171922,8 +171922,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.5">
-          <h3>26.60. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-54.5)</code>
+        <div class="sect2" id="local-type.typedef-60.5">
+          <h3>26.60. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-60.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -171943,7 +171943,7 @@
                       <br/>
                       <code>  /SecondaryReasons/Reason #complexType</code>
                       <br/>
-                      <code>  (typedef-54.5)</code>
+                      <code>  (typedef-60.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -172351,8 +172351,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.14">
-          <h3>26.61. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-54.14)</code>
+        <div class="sect2" id="local-type.typedef-60.14">
+          <h3>26.61. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-60.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172372,7 +172372,7 @@
                       <br/>
                       <code>  /Images #complexType</code>
                       <br/>
-                      <code>  (typedef-54.14)</code>
+                      <code>  (typedef-60.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -172402,7 +172402,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.15" title="local-type: typedef-54.15">local-type: typedef-54.15</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.15" title="local-type: typedef-60.15">local-type: typedef-60.15</a>
                       </em>
                     </p>
                   </td>
@@ -172414,8 +172414,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.15">
-          <h3>26.62. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-54.15)</code>
+        <div class="sect2" id="local-type.typedef-60.15">
+          <h3>26.62. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-60.15)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172435,7 +172435,7 @@
                       <br/>
                       <code>  /Images/Image #complexType</code>
                       <br/>
-                      <code>  (typedef-54.15)</code>
+                      <code>  (typedef-60.15)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -172550,8 +172550,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.16">
-          <h3>26.63. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-54.16)</code>
+        <div class="sect2" id="local-type.typedef-60.16">
+          <h3>26.63. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-60.16)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172571,7 +172571,7 @@
                       <br/>
                       <code>  /InfoLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-54.16)</code>
+                      <code>  (typedef-60.16)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -172613,8 +172613,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.2">
-          <h3>26.64. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-54.2)</code>
+        <div class="sect2" id="local-type.typedef-60.2">
+          <h3>26.64. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-60.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172634,7 +172634,7 @@
                       <br/>
                       <code>  /Repetitions #complexType</code>
                       <br/>
-                      <code>  (typedef-54.2)</code>
+                      <code>  (typedef-60.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -172678,8 +172678,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.4">
-          <h3>26.65. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-54.4)</code>
+        <div class="sect2" id="local-type.typedef-60.4">
+          <h3>26.65. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-60.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172699,7 +172699,7 @@
                       <br/>
                       <code>  /SecondaryReasons #complexType</code>
                       <br/>
-                      <code>  (typedef-54.4)</code>
+                      <code>  (typedef-60.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -172729,7 +172729,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.5" title="local-type: typedef-54.5">local-type: typedef-54.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.5" title="local-type: typedef-60.5">local-type: typedef-60.5</a>
                       </em>
                     </p>
                   </td>
@@ -172741,8 +172741,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.5">
-          <h3>26.66. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-54.5)</code>
+        <div class="sect2" id="local-type.typedef-60.5">
+          <h3>26.66. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-60.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172762,7 +172762,7 @@
                       <br/>
                       <code>  /SecondaryReasons/Reason #complexType</code>
                       <br/>
-                      <code>  (typedef-54.5)</code>
+                      <code>  (typedef-60.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -173170,8 +173170,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.14">
-          <h3>26.67. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-54.14)</code>
+        <div class="sect2" id="local-type.typedef-60.14">
+          <h3>26.67. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-60.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -173191,7 +173191,7 @@
                       <br/>
                       <code>  /Images #complexType</code>
                       <br/>
-                      <code>  (typedef-54.14)</code>
+                      <code>  (typedef-60.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -173221,7 +173221,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.15" title="local-type: typedef-54.15">local-type: typedef-54.15</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.15" title="local-type: typedef-60.15">local-type: typedef-60.15</a>
                       </em>
                     </p>
                   </td>
@@ -173233,8 +173233,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.15">
-          <h3>26.68. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-54.15)</code>
+        <div class="sect2" id="local-type.typedef-60.15">
+          <h3>26.68. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-60.15)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -173254,7 +173254,7 @@
                       <br/>
                       <code>  /Images/Image #complexType</code>
                       <br/>
-                      <code>  (typedef-54.15)</code>
+                      <code>  (typedef-60.15)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -173369,8 +173369,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.16">
-          <h3>26.69. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-54.16)</code>
+        <div class="sect2" id="local-type.typedef-60.16">
+          <h3>26.69. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-60.16)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -173390,7 +173390,7 @@
                       <br/>
                       <code>  /InfoLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-54.16)</code>
+                      <code>  (typedef-60.16)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -173432,8 +173432,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.2">
-          <h3>26.70. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-54.2)</code>
+        <div class="sect2" id="local-type.typedef-60.2">
+          <h3>26.70. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-60.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -173453,7 +173453,7 @@
                       <br/>
                       <code>  /Repetitions #complexType</code>
                       <br/>
-                      <code>  (typedef-54.2)</code>
+                      <code>  (typedef-60.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -173497,8 +173497,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.6">
-          <h3>26.71. The complex type <code>complexType[siri:AffectsScopeStructure]/Operators#complexType (typedef-54.6)</code>
+        <div class="sect2" id="local-type.typedef-60.6">
+          <h3>26.71. The complex type <code>complexType[siri:AffectsScopeStructure]/Operators#complexType (typedef-60.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -173518,7 +173518,7 @@
                       <br/>
                       <code>  /Operators #complexType</code>
                       <br/>
-                      <code>  (typedef-54.6)</code>
+                      <code>  (typedef-60.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -173604,8 +173604,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.7">
-          <h3>26.72. The complex type <code>complexType[siri:AffectsScopeStructure]/Networks#complexType (typedef-54.7)</code>
+        <div class="sect2" id="local-type.typedef-60.7">
+          <h3>26.72. The complex type <code>complexType[siri:AffectsScopeStructure]/Networks#complexType (typedef-60.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -173625,7 +173625,7 @@
                       <br/>
                       <code>  /Networks #complexType</code>
                       <br/>
-                      <code>  (typedef-54.7)</code>
+                      <code>  (typedef-60.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -173655,7 +173655,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.8" title="local-type: typedef-54.8">local-type: typedef-54.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.8" title="local-type: typedef-60.8">local-type: typedef-60.8</a>
                       </em>
                     </p>
                   </td>
@@ -173667,8 +173667,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.8">
-          <h3>26.73. The complex type <code>complexType[siri:AffectsScopeStructure]/Networks/AffectedNetwork#complexType (typedef-54.8)</code>
+        <div class="sect2" id="local-type.typedef-60.8">
+          <h3>26.73. The complex type <code>complexType[siri:AffectsScopeStructure]/Networks/AffectedNetwork#complexType (typedef-60.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -173688,7 +173688,7 @@
                       <br/>
                       <code>  /Networks/AffectedNetwork #complexType</code>
                       <br/>
-                      <code>  (typedef-54.8)</code>
+                      <code>  (typedef-60.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -174283,8 +174283,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.9">
-          <h3>26.74. The complex type <code>complexType[siri:AffectsScopeStructure]/StopPoints#complexType (typedef-54.9)</code>
+        <div class="sect2" id="local-type.typedef-60.9">
+          <h3>26.74. The complex type <code>complexType[siri:AffectsScopeStructure]/StopPoints#complexType (typedef-60.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -174304,7 +174304,7 @@
                       <br/>
                       <code>  /StopPoints #complexType</code>
                       <br/>
-                      <code>  (typedef-54.9)</code>
+                      <code>  (typedef-60.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -174346,8 +174346,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.10">
-          <h3>26.75. The complex type <code>complexType[siri:AffectsScopeStructure]/StopPlaces#complexType (typedef-54.10)</code>
+        <div class="sect2" id="local-type.typedef-60.10">
+          <h3>26.75. The complex type <code>complexType[siri:AffectsScopeStructure]/StopPlaces#complexType (typedef-60.10)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -174367,7 +174367,7 @@
                       <br/>
                       <code>  /StopPlaces #complexType</code>
                       <br/>
-                      <code>  (typedef-54.10)</code>
+                      <code>  (typedef-60.10)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -174409,8 +174409,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.11">
-          <h3>26.76. The complex type <code>complexType[siri:AffectsScopeStructure]/Places#complexType (typedef-54.11)</code>
+        <div class="sect2" id="local-type.typedef-60.11">
+          <h3>26.76. The complex type <code>complexType[siri:AffectsScopeStructure]/Places#complexType (typedef-60.11)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -174430,7 +174430,7 @@
                       <br/>
                       <code>  /Places #complexType</code>
                       <br/>
-                      <code>  (typedef-54.11)</code>
+                      <code>  (typedef-60.11)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -174472,8 +174472,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.12">
-          <h3>26.77. The complex type <code>complexType[siri:AffectsScopeStructure]/VehicleJourneys#complexType (typedef-54.12)</code>
+        <div class="sect2" id="local-type.typedef-60.12">
+          <h3>26.77. The complex type <code>complexType[siri:AffectsScopeStructure]/VehicleJourneys#complexType (typedef-60.12)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -174493,7 +174493,7 @@
                       <br/>
                       <code>  /VehicleJourneys #complexType</code>
                       <br/>
-                      <code>  (typedef-54.12)</code>
+                      <code>  (typedef-60.12)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -174535,8 +174535,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.13">
-          <h3>26.78. The complex type <code>complexType[siri:AffectsScopeStructure]/Vehicles#complexType (typedef-54.13)</code>
+        <div class="sect2" id="local-type.typedef-60.13">
+          <h3>26.78. The complex type <code>complexType[siri:AffectsScopeStructure]/Vehicles#complexType (typedef-60.13)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -174556,7 +174556,7 @@
                       <br/>
                       <code>  /Vehicles #complexType</code>
                       <br/>
-                      <code>  (typedef-54.13)</code>
+                      <code>  (typedef-60.13)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -174598,8 +174598,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.17">
-          <h3>26.79. The complex type <code>complexType[siri:PtConsequenceStructure]/Suitabilities#complexType (typedef-54.17)</code>
+        <div class="sect2" id="local-type.typedef-60.17">
+          <h3>26.79. The complex type <code>complexType[siri:PtConsequenceStructure]/Suitabilities#complexType (typedef-60.17)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -174619,7 +174619,7 @@
                       <br/>
                       <code>  /Suitabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-54.17)</code>
+                      <code>  (typedef-60.17)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -174661,8 +174661,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.2">
-          <h3>26.80. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-54.2)</code>
+        <div class="sect2" id="local-type.typedef-60.2">
+          <h3>26.80. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-60.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -174682,7 +174682,7 @@
                       <br/>
                       <code>  /Repetitions #complexType</code>
                       <br/>
-                      <code>  (typedef-54.2)</code>
+                      <code>  (typedef-60.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -174726,8 +174726,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.4">
-          <h3>26.81. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-54.4)</code>
+        <div class="sect2" id="local-type.typedef-60.4">
+          <h3>26.81. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-60.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -174747,7 +174747,7 @@
                       <br/>
                       <code>  /SecondaryReasons #complexType</code>
                       <br/>
-                      <code>  (typedef-54.4)</code>
+                      <code>  (typedef-60.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -174777,7 +174777,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.5" title="local-type: typedef-54.5">local-type: typedef-54.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.5" title="local-type: typedef-60.5">local-type: typedef-60.5</a>
                       </em>
                     </p>
                   </td>
@@ -174789,8 +174789,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.5">
-          <h3>26.82. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-54.5)</code>
+        <div class="sect2" id="local-type.typedef-60.5">
+          <h3>26.82. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-60.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -174810,7 +174810,7 @@
                       <br/>
                       <code>  /SecondaryReasons/Reason #complexType</code>
                       <br/>
-                      <code>  (typedef-54.5)</code>
+                      <code>  (typedef-60.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -175218,8 +175218,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.14">
-          <h3>26.83. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-54.14)</code>
+        <div class="sect2" id="local-type.typedef-60.14">
+          <h3>26.83. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-60.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -175239,7 +175239,7 @@
                       <br/>
                       <code>  /Images #complexType</code>
                       <br/>
-                      <code>  (typedef-54.14)</code>
+                      <code>  (typedef-60.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -175269,7 +175269,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.15" title="local-type: typedef-54.15">local-type: typedef-54.15</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.15" title="local-type: typedef-60.15">local-type: typedef-60.15</a>
                       </em>
                     </p>
                   </td>
@@ -175281,8 +175281,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.15">
-          <h3>26.84. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-54.15)</code>
+        <div class="sect2" id="local-type.typedef-60.15">
+          <h3>26.84. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-60.15)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -175302,7 +175302,7 @@
                       <br/>
                       <code>  /Images/Image #complexType</code>
                       <br/>
-                      <code>  (typedef-54.15)</code>
+                      <code>  (typedef-60.15)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -175417,8 +175417,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.16">
-          <h3>26.85. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-54.16)</code>
+        <div class="sect2" id="local-type.typedef-60.16">
+          <h3>26.85. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-60.16)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -175438,7 +175438,7 @@
                       <br/>
                       <code>  /InfoLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-54.16)</code>
+                      <code>  (typedef-60.16)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -175480,8 +175480,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.2">
-          <h3>26.86. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-54.2)</code>
+        <div class="sect2" id="local-type.typedef-60.2">
+          <h3>26.86. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-60.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -175501,7 +175501,7 @@
                       <br/>
                       <code>  /Repetitions #complexType</code>
                       <br/>
-                      <code>  (typedef-54.2)</code>
+                      <code>  (typedef-60.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -175545,8 +175545,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.4">
-          <h3>26.87. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-54.4)</code>
+        <div class="sect2" id="local-type.typedef-60.4">
+          <h3>26.87. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-60.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -175566,7 +175566,7 @@
                       <br/>
                       <code>  /SecondaryReasons #complexType</code>
                       <br/>
-                      <code>  (typedef-54.4)</code>
+                      <code>  (typedef-60.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -175596,7 +175596,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.5" title="local-type: typedef-54.5">local-type: typedef-54.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.5" title="local-type: typedef-60.5">local-type: typedef-60.5</a>
                       </em>
                     </p>
                   </td>
@@ -175608,8 +175608,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.5">
-          <h3>26.88. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-54.5)</code>
+        <div class="sect2" id="local-type.typedef-60.5">
+          <h3>26.88. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-60.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -175629,7 +175629,7 @@
                       <br/>
                       <code>  /SecondaryReasons/Reason #complexType</code>
                       <br/>
-                      <code>  (typedef-54.5)</code>
+                      <code>  (typedef-60.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -176037,8 +176037,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.14">
-          <h3>26.89. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-54.14)</code>
+        <div class="sect2" id="local-type.typedef-60.14">
+          <h3>26.89. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-60.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -176058,7 +176058,7 @@
                       <br/>
                       <code>  /Images #complexType</code>
                       <br/>
-                      <code>  (typedef-54.14)</code>
+                      <code>  (typedef-60.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -176088,7 +176088,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.15" title="local-type: typedef-54.15">local-type: typedef-54.15</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.15" title="local-type: typedef-60.15">local-type: typedef-60.15</a>
                       </em>
                     </p>
                   </td>
@@ -176100,8 +176100,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.15">
-          <h3>26.90. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-54.15)</code>
+        <div class="sect2" id="local-type.typedef-60.15">
+          <h3>26.90. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-60.15)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -176121,7 +176121,7 @@
                       <br/>
                       <code>  /Images/Image #complexType</code>
                       <br/>
-                      <code>  (typedef-54.15)</code>
+                      <code>  (typedef-60.15)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -176236,8 +176236,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.16">
-          <h3>26.91. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-54.16)</code>
+        <div class="sect2" id="local-type.typedef-60.16">
+          <h3>26.91. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-60.16)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -176257,7 +176257,7 @@
                       <br/>
                       <code>  /InfoLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-54.16)</code>
+                      <code>  (typedef-60.16)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -177041,7 +177041,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-46.3" title="local-type: typedef-46.3">local-type: typedef-46.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-54.3" title="local-type: typedef-54.3">local-type: typedef-54.3</a>
                       </em>
                     </p>
                   </td>
@@ -177289,7 +177289,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-46.2" title="local-type: typedef-46.2">local-type: typedef-46.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-54.2" title="local-type: typedef-54.2">local-type: typedef-54.2</a>
                       </em>
                     </p>
                   </td>
@@ -177455,7 +177455,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-46.3" title="local-type: typedef-46.3">local-type: typedef-46.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-54.3" title="local-type: typedef-54.3">local-type: typedef-54.3</a>
                       </em>
                     </p>
                   </td>
@@ -178107,7 +178107,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-46.1" title="local-type: typedef-46.1">local-type: typedef-46.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-54.1" title="local-type: typedef-54.1">local-type: typedef-54.1</a>
                       </em>
                     </p>
                   </td>
@@ -178319,7 +178319,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-46.1" title="local-type: typedef-46.1">local-type: typedef-46.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-54.1" title="local-type: typedef-54.1">local-type: typedef-54.1</a>
                       </em>
                     </p>
                   </td>
@@ -178552,7 +178552,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-46.1" title="local-type: typedef-46.1">local-type: typedef-46.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-54.1" title="local-type: typedef-54.1">local-type: typedef-54.1</a>
                       </em>
                     </p>
                   </td>
@@ -178787,7 +178787,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-46.1" title="local-type: typedef-46.1">local-type: typedef-46.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-54.1" title="local-type: typedef-54.1">local-type: typedef-54.1</a>
                       </em>
                     </p>
                   </td>
@@ -179430,7 +179430,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-46.4" title="local-type: typedef-46.4">local-type: typedef-46.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-54.4" title="local-type: typedef-54.4">local-type: typedef-54.4</a>
                       </em>
                     </p>
                   </td>
@@ -179618,7 +179618,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-46.1" title="local-type: typedef-46.1">local-type: typedef-46.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-54.1" title="local-type: typedef-54.1">local-type: typedef-54.1</a>
                       </em>
                     </p>
                   </td>
@@ -180646,7 +180646,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-46.1" title="local-type: typedef-46.1">local-type: typedef-46.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-54.1" title="local-type: typedef-54.1">local-type: typedef-54.1</a>
                       </em>
                     </p>
                   </td>
@@ -181196,7 +181196,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-46.3" title="local-type: typedef-46.3">local-type: typedef-46.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-54.3" title="local-type: typedef-54.3">local-type: typedef-54.3</a>
                       </em>
                     </p>
                   </td>
@@ -181540,8 +181540,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-46.3">
-          <h3>27.41. The complex type <code>element[siri:ManualAction]#complexType (typedef-46.3)</code>
+        <div class="sect2" id="local-type.typedef-54.3">
+          <h3>27.41. The complex type <code>element[siri:ManualAction]#complexType (typedef-54.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -181561,7 +181561,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-46.3)</code>
+                      <code>  (typedef-54.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -181679,8 +181679,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-46.3">
-          <h3>27.42. The complex type <code>element[siri:ManualAction]#complexType (typedef-46.3)</code>
+        <div class="sect2" id="local-type.typedef-54.3">
+          <h3>27.42. The complex type <code>element[siri:ManualAction]#complexType (typedef-54.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -181700,7 +181700,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-46.3)</code>
+                      <code>  (typedef-54.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -181818,8 +181818,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-46.2">
-          <h3>27.43. The complex type <code>complexType[siri:ActionDataStructure]/PublishAtScope#complexType (typedef-46.2)</code>
+        <div class="sect2" id="local-type.typedef-54.2">
+          <h3>27.43. The complex type <code>complexType[siri:ActionDataStructure]/PublishAtScope#complexType (typedef-54.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -181839,7 +181839,7 @@
                       <br/>
                       <code>  /PublishAtScope #complexType</code>
                       <br/>
-                      <code>  (typedef-46.2)</code>
+                      <code>  (typedef-54.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -181906,8 +181906,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-46.3">
-          <h3>27.44. The complex type <code>element[siri:ManualAction]#complexType (typedef-46.3)</code>
+        <div class="sect2" id="local-type.typedef-54.3">
+          <h3>27.44. The complex type <code>element[siri:ManualAction]#complexType (typedef-54.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -181927,7 +181927,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-46.3)</code>
+                      <code>  (typedef-54.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -182045,8 +182045,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-46.1">
-          <h3>27.45. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-46.1)</code>
+        <div class="sect2" id="local-type.typedef-54.1">
+          <h3>27.45. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-54.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -182066,7 +182066,7 @@
                       <br/>
                       <code>  /BeforeNotices #complexType</code>
                       <br/>
-                      <code>  (typedef-46.1)</code>
+                      <code>  (typedef-54.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -182105,8 +182105,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-46.1">
-          <h3>27.46. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-46.1)</code>
+        <div class="sect2" id="local-type.typedef-54.1">
+          <h3>27.46. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-54.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -182126,7 +182126,7 @@
                       <br/>
                       <code>  /BeforeNotices #complexType</code>
                       <br/>
-                      <code>  (typedef-46.1)</code>
+                      <code>  (typedef-54.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -182165,8 +182165,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-46.1">
-          <h3>27.47. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-46.1)</code>
+        <div class="sect2" id="local-type.typedef-54.1">
+          <h3>27.47. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-54.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -182186,7 +182186,7 @@
                       <br/>
                       <code>  /BeforeNotices #complexType</code>
                       <br/>
-                      <code>  (typedef-46.1)</code>
+                      <code>  (typedef-54.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -182225,8 +182225,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-46.1">
-          <h3>27.48. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-46.1)</code>
+        <div class="sect2" id="local-type.typedef-54.1">
+          <h3>27.48. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-54.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -182246,7 +182246,7 @@
                       <br/>
                       <code>  /BeforeNotices #complexType</code>
                       <br/>
-                      <code>  (typedef-46.1)</code>
+                      <code>  (typedef-54.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -182285,8 +182285,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-46.4">
-          <h3>27.49. The complex type <code>complexType[siri:PublishingActionStructure]/PublishAtScope#complexType (typedef-46.4)</code>
+        <div class="sect2" id="local-type.typedef-54.4">
+          <h3>27.49. The complex type <code>complexType[siri:PublishingActionStructure]/PublishAtScope#complexType (typedef-54.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -182306,7 +182306,7 @@
                       <br/>
                       <code>  /PublishAtScope #complexType</code>
                       <br/>
-                      <code>  (typedef-46.4)</code>
+                      <code>  (typedef-54.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -182373,8 +182373,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-46.1">
-          <h3>27.50. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-46.1)</code>
+        <div class="sect2" id="local-type.typedef-54.1">
+          <h3>27.50. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-54.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -182394,7 +182394,7 @@
                       <br/>
                       <code>  /BeforeNotices #complexType</code>
                       <br/>
-                      <code>  (typedef-46.1)</code>
+                      <code>  (typedef-54.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -182433,8 +182433,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-46.1">
-          <h3>27.51. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-46.1)</code>
+        <div class="sect2" id="local-type.typedef-54.1">
+          <h3>27.51. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-54.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -182454,7 +182454,7 @@
                       <br/>
                       <code>  /BeforeNotices #complexType</code>
                       <br/>
-                      <code>  (typedef-46.1)</code>
+                      <code>  (typedef-54.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -182493,8 +182493,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-46.3">
-          <h3>27.52. The complex type <code>element[siri:ManualAction]#complexType (typedef-46.3)</code>
+        <div class="sect2" id="local-type.typedef-54.3">
+          <h3>27.52. The complex type <code>element[siri:ManualAction]#complexType (typedef-54.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -182514,7 +182514,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-46.3)</code>
+                      <code>  (typedef-54.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -184383,7 +184383,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.1" title="local-type: typedef-48.1">local-type: typedef-48.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.1" title="local-type: typedef-64.1">local-type: typedef-64.1</a>
                       </em>
                     </p>
                   </td>
@@ -184407,7 +184407,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.2" title="local-type: typedef-48.2">local-type: typedef-48.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.2" title="local-type: typedef-64.2">local-type: typedef-64.2</a>
                       </em>
                     </p>
                   </td>
@@ -185013,7 +185013,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.16" title="local-type: typedef-48.16">local-type: typedef-48.16</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.16" title="local-type: typedef-64.16">local-type: typedef-64.16</a>
                       </em>
                     </p>
                   </td>
@@ -185971,7 +185971,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.4" title="local-type: typedef-48.4">local-type: typedef-48.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.4" title="local-type: typedef-64.4">local-type: typedef-64.4</a>
                       </em>
                     </p>
                   </td>
@@ -185995,7 +185995,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.5" title="local-type: typedef-48.5">local-type: typedef-48.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.5" title="local-type: typedef-64.5">local-type: typedef-64.5</a>
                       </em>
                     </p>
                   </td>
@@ -186019,7 +186019,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.6" title="local-type: typedef-48.6">local-type: typedef-48.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.6" title="local-type: typedef-64.6">local-type: typedef-64.6</a>
                       </em>
                     </p>
                   </td>
@@ -186043,7 +186043,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.7" title="local-type: typedef-48.7">local-type: typedef-48.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.7" title="local-type: typedef-64.7">local-type: typedef-64.7</a>
                       </em>
                     </p>
                   </td>
@@ -186269,7 +186269,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.3" title="local-type: typedef-48.3">local-type: typedef-48.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.3" title="local-type: typedef-64.3">local-type: typedef-64.3</a>
                       </em>
                     </p>
                   </td>
@@ -187545,7 +187545,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.9" title="local-type: typedef-48.9">local-type: typedef-48.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.9" title="local-type: typedef-64.9">local-type: typedef-64.9</a>
                       </em>
                     </p>
                   </td>
@@ -187569,7 +187569,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.10" title="local-type: typedef-48.10">local-type: typedef-48.10</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.10" title="local-type: typedef-64.10">local-type: typedef-64.10</a>
                       </em>
                     </p>
                   </td>
@@ -187593,7 +187593,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.11" title="local-type: typedef-48.11">local-type: typedef-48.11</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.11" title="local-type: typedef-64.11">local-type: typedef-64.11</a>
                       </em>
                     </p>
                   </td>
@@ -187716,7 +187716,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.8" title="local-type: typedef-48.8">local-type: typedef-48.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.8" title="local-type: typedef-64.8">local-type: typedef-64.8</a>
                       </em>
                     </p>
                   </td>
@@ -188072,7 +188072,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.21" title="local-type: typedef-48.21">local-type: typedef-48.21</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.21" title="local-type: typedef-64.21">local-type: typedef-64.21</a>
                       </em>
                     </p>
                   </td>
@@ -188315,7 +188315,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.18" title="local-type: typedef-48.18">local-type: typedef-48.18</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.18" title="local-type: typedef-64.18">local-type: typedef-64.18</a>
                       </em>
                     </p>
                   </td>
@@ -188339,7 +188339,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.19" title="local-type: typedef-48.19">local-type: typedef-48.19</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.19" title="local-type: typedef-64.19">local-type: typedef-64.19</a>
                       </em>
                     </p>
                   </td>
@@ -188363,7 +188363,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.20" title="local-type: typedef-48.20">local-type: typedef-48.20</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.20" title="local-type: typedef-64.20">local-type: typedef-64.20</a>
                       </em>
                     </p>
                   </td>
@@ -188392,7 +188392,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.17" title="local-type: typedef-48.17">local-type: typedef-48.17</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.17" title="local-type: typedef-64.17">local-type: typedef-64.17</a>
                       </em>
                     </p>
                   </td>
@@ -188585,7 +188585,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.18" title="local-type: typedef-48.18">local-type: typedef-48.18</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.18" title="local-type: typedef-64.18">local-type: typedef-64.18</a>
                       </em>
                     </p>
                   </td>
@@ -188609,7 +188609,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.19" title="local-type: typedef-48.19">local-type: typedef-48.19</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.19" title="local-type: typedef-64.19">local-type: typedef-64.19</a>
                       </em>
                     </p>
                   </td>
@@ -188633,7 +188633,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.20" title="local-type: typedef-48.20">local-type: typedef-48.20</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.20" title="local-type: typedef-64.20">local-type: typedef-64.20</a>
                       </em>
                     </p>
                   </td>
@@ -188985,7 +188985,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.1" title="local-type: typedef-48.1">local-type: typedef-48.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.1" title="local-type: typedef-64.1">local-type: typedef-64.1</a>
                       </em>
                     </p>
                   </td>
@@ -189014,7 +189014,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.2" title="local-type: typedef-48.2">local-type: typedef-48.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.2" title="local-type: typedef-64.2">local-type: typedef-64.2</a>
                       </em>
                     </p>
                   </td>
@@ -189384,7 +189384,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.1" title="local-type: typedef-48.1">local-type: typedef-48.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.1" title="local-type: typedef-64.1">local-type: typedef-64.1</a>
                       </em>
                     </p>
                   </td>
@@ -189679,7 +189679,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.12" title="local-type: typedef-48.12">local-type: typedef-48.12</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.12" title="local-type: typedef-64.12">local-type: typedef-64.12</a>
                       </em>
                     </p>
                   </td>
@@ -189703,7 +189703,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.13" title="local-type: typedef-48.13">local-type: typedef-48.13</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.13" title="local-type: typedef-64.13">local-type: typedef-64.13</a>
                       </em>
                     </p>
                   </td>
@@ -189942,7 +189942,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.14" title="local-type: typedef-48.14">local-type: typedef-48.14</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.14" title="local-type: typedef-64.14">local-type: typedef-64.14</a>
                       </em>
                     </p>
                   </td>
@@ -189966,7 +189966,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-48.15" title="local-type: typedef-48.15">local-type: typedef-48.15</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-64.15" title="local-type: typedef-64.15">local-type: typedef-64.15</a>
                       </em>
                     </p>
                   </td>
@@ -191186,8 +191186,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.1">
-          <h3>28.44. The complex type <code>complexType[siri:AffectedStopPointWithoutLineStructure]/ConnectionLinks#complexType (typedef-48.1)</code>
+        <div class="sect2" id="local-type.typedef-64.1">
+          <h3>28.44. The complex type <code>complexType[siri:AffectedStopPointWithoutLineStructure]/ConnectionLinks#complexType (typedef-64.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -191207,7 +191207,7 @@
                       <br/>
                       <code>  /ConnectionLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-48.1)</code>
+                      <code>  (typedef-64.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -191249,8 +191249,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.2">
-          <h3>28.45. The complex type <code>complexType[siri:AffectedStopPointStructure]/Lines#complexType (typedef-48.2)</code>
+        <div class="sect2" id="local-type.typedef-64.2">
+          <h3>28.45. The complex type <code>complexType[siri:AffectedStopPointStructure]/Lines#complexType (typedef-64.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -191270,7 +191270,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-48.2)</code>
+                      <code>  (typedef-64.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -191312,8 +191312,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.16">
-          <h3>28.46. The complex type <code>complexType[siri:AffectedCallStructure]/AffectedInterchanges#complexType (typedef-48.16)</code>
+        <div class="sect2" id="local-type.typedef-64.16">
+          <h3>28.46. The complex type <code>complexType[siri:AffectedCallStructure]/AffectedInterchanges#complexType (typedef-64.16)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -191333,7 +191333,7 @@
                       <br/>
                       <code>  /AffectedInterchanges #complexType</code>
                       <br/>
-                      <code>  (typedef-48.16)</code>
+                      <code>  (typedef-64.16)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -191371,8 +191371,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.4">
-          <h3>28.47. The complex type <code>complexType[siri:AffectedLineStructure]/Routes#complexType (typedef-48.4)</code>
+        <div class="sect2" id="local-type.typedef-64.4">
+          <h3>28.47. The complex type <code>complexType[siri:AffectedLineStructure]/Routes#complexType (typedef-64.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -191392,7 +191392,7 @@
                       <br/>
                       <code>  /Routes #complexType</code>
                       <br/>
-                      <code>  (typedef-48.4)</code>
+                      <code>  (typedef-64.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -191434,8 +191434,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.5">
-          <h3>28.48. The complex type <code>complexType[siri:AffectedLineStructure]/Sections#complexType (typedef-48.5)</code>
+        <div class="sect2" id="local-type.typedef-64.5">
+          <h3>28.48. The complex type <code>complexType[siri:AffectedLineStructure]/Sections#complexType (typedef-64.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -191455,7 +191455,7 @@
                       <br/>
                       <code>  /Sections #complexType</code>
                       <br/>
-                      <code>  (typedef-48.5)</code>
+                      <code>  (typedef-64.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -191497,8 +191497,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.6">
-          <h3>28.49. The complex type <code>complexType[siri:AffectedLineStructure]/StopPoints#complexType (typedef-48.6)</code>
+        <div class="sect2" id="local-type.typedef-64.6">
+          <h3>28.49. The complex type <code>complexType[siri:AffectedLineStructure]/StopPoints#complexType (typedef-64.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -191518,7 +191518,7 @@
                       <br/>
                       <code>  /StopPoints #complexType</code>
                       <br/>
-                      <code>  (typedef-48.6)</code>
+                      <code>  (typedef-64.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -191560,8 +191560,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.7">
-          <h3>28.50. The complex type <code>complexType[siri:AffectedLineStructure]/StopPlaces#complexType (typedef-48.7)</code>
+        <div class="sect2" id="local-type.typedef-64.7">
+          <h3>28.50. The complex type <code>complexType[siri:AffectedLineStructure]/StopPlaces#complexType (typedef-64.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -191581,7 +191581,7 @@
                       <br/>
                       <code>  /StopPlaces #complexType</code>
                       <br/>
-                      <code>  (typedef-48.7)</code>
+                      <code>  (typedef-64.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -191623,8 +191623,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.3">
-          <h3>28.51. The complex type <code>complexType[siri:AffectedModesStructure]/Mode#complexType (typedef-48.3)</code>
+        <div class="sect2" id="local-type.typedef-64.3">
+          <h3>28.51. The complex type <code>complexType[siri:AffectedModesStructure]/Mode#complexType (typedef-64.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -191644,7 +191644,7 @@
                       <br/>
                       <code>  /Mode #complexType</code>
                       <br/>
-                      <code>  (typedef-48.3)</code>
+                      <code>  (typedef-64.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -191973,8 +191973,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.9">
-          <h3>28.52. The complex type <code>complexType[siri:AffectedRouteStructure]/Sections#complexType (typedef-48.9)</code>
+        <div class="sect2" id="local-type.typedef-64.9">
+          <h3>28.52. The complex type <code>complexType[siri:AffectedRouteStructure]/Sections#complexType (typedef-64.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -191994,7 +191994,7 @@
                       <br/>
                       <code>  /Sections #complexType</code>
                       <br/>
-                      <code>  (typedef-48.9)</code>
+                      <code>  (typedef-64.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192036,8 +192036,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.10">
-          <h3>28.53. The complex type <code>complexType[siri:AffectedRouteStructure]/StopPoints#complexType (typedef-48.10)</code>
+        <div class="sect2" id="local-type.typedef-64.10">
+          <h3>28.53. The complex type <code>complexType[siri:AffectedRouteStructure]/StopPoints#complexType (typedef-64.10)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192057,7 +192057,7 @@
                       <br/>
                       <code>  /StopPoints #complexType</code>
                       <br/>
-                      <code>  (typedef-48.10)</code>
+                      <code>  (typedef-64.10)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192146,8 +192146,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.11">
-          <h3>28.54. The complex type <code>complexType[siri:AffectedRouteStructure]/RouteLinks#complexType (typedef-48.11)</code>
+        <div class="sect2" id="local-type.typedef-64.11">
+          <h3>28.54. The complex type <code>complexType[siri:AffectedRouteStructure]/RouteLinks#complexType (typedef-64.11)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192167,7 +192167,7 @@
                       <br/>
                       <code>  /RouteLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-48.11)</code>
+                      <code>  (typedef-64.11)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192209,8 +192209,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.8">
-          <h3>28.55. The complex type <code>complexType[siri:AffectedSectionStructure]/IndirectSectionRef#complexType (typedef-48.8)</code>
+        <div class="sect2" id="local-type.typedef-64.8">
+          <h3>28.55. The complex type <code>complexType[siri:AffectedSectionStructure]/IndirectSectionRef#complexType (typedef-64.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192230,7 +192230,7 @@
                       <br/>
                       <code>  /IndirectSectionRef #complexType</code>
                       <br/>
-                      <code>  (typedef-48.8)</code>
+                      <code>  (typedef-64.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192556,8 +192556,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.21">
-          <h3>28.56. The complex type <code>complexType[siri:AffectedStopPlaceComponentStructure]/AffectedFacilities#complexType (typedef-48.21)</code>
+        <div class="sect2" id="local-type.typedef-64.21">
+          <h3>28.56. The complex type <code>complexType[siri:AffectedStopPlaceComponentStructure]/AffectedFacilities#complexType (typedef-64.21)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192577,7 +192577,7 @@
                       <br/>
                       <code>  /AffectedFacilities #complexType</code>
                       <br/>
-                      <code>  (typedef-48.21)</code>
+                      <code>  (typedef-64.21)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192619,8 +192619,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.18">
-          <h3>28.57. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedFacilities#complexType (typedef-48.18)</code>
+        <div class="sect2" id="local-type.typedef-64.18">
+          <h3>28.57. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedFacilities#complexType (typedef-64.18)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192640,7 +192640,7 @@
                       <br/>
                       <code>  /AffectedFacilities #complexType</code>
                       <br/>
-                      <code>  (typedef-48.18)</code>
+                      <code>  (typedef-64.18)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192682,8 +192682,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.19">
-          <h3>28.58. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedComponents#complexType (typedef-48.19)</code>
+        <div class="sect2" id="local-type.typedef-64.19">
+          <h3>28.58. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedComponents#complexType (typedef-64.19)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192703,7 +192703,7 @@
                       <br/>
                       <code>  /AffectedComponents #complexType</code>
                       <br/>
-                      <code>  (typedef-48.19)</code>
+                      <code>  (typedef-64.19)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192741,8 +192741,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.20">
-          <h3>28.59. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedNavigationPaths#complexType (typedef-48.20)</code>
+        <div class="sect2" id="local-type.typedef-64.20">
+          <h3>28.59. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedNavigationPaths#complexType (typedef-64.20)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192762,7 +192762,7 @@
                       <br/>
                       <code>  /AffectedNavigationPaths #complexType</code>
                       <br/>
-                      <code>  (typedef-48.20)</code>
+                      <code>  (typedef-64.20)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192804,8 +192804,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.17">
-          <h3>28.60. The complex type <code>complexType[siri:AffectedStopPlaceStructure]/Lines#complexType (typedef-48.17)</code>
+        <div class="sect2" id="local-type.typedef-64.17">
+          <h3>28.60. The complex type <code>complexType[siri:AffectedStopPlaceStructure]/Lines#complexType (typedef-64.17)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192825,7 +192825,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-48.17)</code>
+                      <code>  (typedef-64.17)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192867,8 +192867,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.18">
-          <h3>28.61. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedFacilities#complexType (typedef-48.18)</code>
+        <div class="sect2" id="local-type.typedef-64.18">
+          <h3>28.61. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedFacilities#complexType (typedef-64.18)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192888,7 +192888,7 @@
                       <br/>
                       <code>  /AffectedFacilities #complexType</code>
                       <br/>
-                      <code>  (typedef-48.18)</code>
+                      <code>  (typedef-64.18)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192930,8 +192930,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.19">
-          <h3>28.62. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedComponents#complexType (typedef-48.19)</code>
+        <div class="sect2" id="local-type.typedef-64.19">
+          <h3>28.62. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedComponents#complexType (typedef-64.19)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192951,7 +192951,7 @@
                       <br/>
                       <code>  /AffectedComponents #complexType</code>
                       <br/>
-                      <code>  (typedef-48.19)</code>
+                      <code>  (typedef-64.19)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192989,8 +192989,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.20">
-          <h3>28.63. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedNavigationPaths#complexType (typedef-48.20)</code>
+        <div class="sect2" id="local-type.typedef-64.20">
+          <h3>28.63. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedNavigationPaths#complexType (typedef-64.20)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193010,7 +193010,7 @@
                       <br/>
                       <code>  /AffectedNavigationPaths #complexType</code>
                       <br/>
-                      <code>  (typedef-48.20)</code>
+                      <code>  (typedef-64.20)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -193052,8 +193052,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.1">
-          <h3>28.64. The complex type <code>complexType[siri:AffectedStopPointWithoutLineStructure]/ConnectionLinks#complexType (typedef-48.1)</code>
+        <div class="sect2" id="local-type.typedef-64.1">
+          <h3>28.64. The complex type <code>complexType[siri:AffectedStopPointWithoutLineStructure]/ConnectionLinks#complexType (typedef-64.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193073,7 +193073,7 @@
                       <br/>
                       <code>  /ConnectionLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-48.1)</code>
+                      <code>  (typedef-64.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -193115,8 +193115,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.2">
-          <h3>28.65. The complex type <code>complexType[siri:AffectedStopPointStructure]/Lines#complexType (typedef-48.2)</code>
+        <div class="sect2" id="local-type.typedef-64.2">
+          <h3>28.65. The complex type <code>complexType[siri:AffectedStopPointStructure]/Lines#complexType (typedef-64.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193136,7 +193136,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-48.2)</code>
+                      <code>  (typedef-64.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -193178,8 +193178,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.1">
-          <h3>28.66. The complex type <code>complexType[siri:AffectedStopPointWithoutLineStructure]/ConnectionLinks#complexType (typedef-48.1)</code>
+        <div class="sect2" id="local-type.typedef-64.1">
+          <h3>28.66. The complex type <code>complexType[siri:AffectedStopPointWithoutLineStructure]/ConnectionLinks#complexType (typedef-64.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193199,7 +193199,7 @@
                       <br/>
                       <code>  /ConnectionLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-48.1)</code>
+                      <code>  (typedef-64.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -193241,8 +193241,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.12">
-          <h3>28.67. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/TrainNumbers#complexType (typedef-48.12)</code>
+        <div class="sect2" id="local-type.typedef-64.12">
+          <h3>28.67. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/TrainNumbers#complexType (typedef-64.12)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193262,7 +193262,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-48.12)</code>
+                      <code>  (typedef-64.12)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -193304,8 +193304,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.13">
-          <h3>28.68. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/JourneyParts#complexType (typedef-48.13)</code>
+        <div class="sect2" id="local-type.typedef-64.13">
+          <h3>28.68. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/JourneyParts#complexType (typedef-64.13)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193325,7 +193325,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-48.13)</code>
+                      <code>  (typedef-64.13)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -193367,8 +193367,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.14">
-          <h3>28.69. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/Calls#complexType (typedef-48.14)</code>
+        <div class="sect2" id="local-type.typedef-64.14">
+          <h3>28.69. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/Calls#complexType (typedef-64.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193388,7 +193388,7 @@
                       <br/>
                       <code>  /Calls #complexType</code>
                       <br/>
-                      <code>  (typedef-48.14)</code>
+                      <code>  (typedef-64.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -193430,8 +193430,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-48.15">
-          <h3>28.70. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/Facilities#complexType (typedef-48.15)</code>
+        <div class="sect2" id="local-type.typedef-64.15">
+          <h3>28.70. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/Facilities#complexType (typedef-64.15)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193451,7 +193451,7 @@
                       <br/>
                       <code>  /Facilities #complexType</code>
                       <br/>
-                      <code>  (typedef-48.15)</code>
+                      <code>  (typedef-64.15)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -194108,12 +194108,12 @@
                 </tr>
                 <tr>
                   <td colspan="1" rowspan="2" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-40.2" class="tableblock">
+                    <p id="local-type.typedef-55.2" class="tableblock">
                       <code>element[siri:Predictability]</code>
                       <br/>
                       <code>  #simpleType</code>
                       <br/>
-                      <code>  (typedef-40.2)</code>
+                      <code>  (typedef-55.2)</code>
                     </p>
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
@@ -194158,12 +194158,12 @@
                 </tr>
                 <tr>
                   <td colspan="1" rowspan="2" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-40.1" class="tableblock">
+                    <p id="local-type.typedef-55.1" class="tableblock">
                       <code>element[siri:VerificationStatus]</code>
                       <br/>
                       <code>  #simpleType</code>
                       <br/>
-                      <code>  (typedef-40.1)</code>
+                      <code>  (typedef-55.1)</code>
                     </p>
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
@@ -203958,7 +203958,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-20.1" title="local-type: typedef-20.1">local-type: typedef-20.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-4.1" title="local-type: typedef-4.1">local-type: typedef-4.1</a>
                       </em>
                     </p>
                   </td>
@@ -203982,7 +203982,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-20.2" title="local-type: typedef-20.2">local-type: typedef-20.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-4.2" title="local-type: typedef-4.2">local-type: typedef-4.2</a>
                       </em>
                     </p>
                   </td>
@@ -204126,7 +204126,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-20.3" title="local-type: typedef-20.3">local-type: typedef-20.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-4.3" title="local-type: typedef-4.3">local-type: typedef-4.3</a>
                       </em>
                     </p>
                   </td>
@@ -204336,7 +204336,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.1" title="local-type: typedef-22.1">local-type: typedef-22.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-2.1" title="local-type: typedef-2.1">local-type: typedef-2.1</a>
                       </em>
                     </p>
                   </td>
@@ -204360,7 +204360,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.2" title="local-type: typedef-22.2">local-type: typedef-22.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-2.2" title="local-type: typedef-2.2">local-type: typedef-2.2</a>
                       </em>
                     </p>
                   </td>
@@ -204524,8 +204524,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-20.1">
-          <h3>38.7. The complex type <code>complexType[siri:AnnotatedLineStructure]/Destinations#complexType (typedef-20.1)</code>
+        <div class="sect2" id="local-type.typedef-4.1">
+          <h3>38.7. The complex type <code>complexType[siri:AnnotatedLineStructure]/Destinations#complexType (typedef-4.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -204545,7 +204545,7 @@
                       <br/>
                       <code>  /Destinations #complexType</code>
                       <br/>
-                      <code>  (typedef-20.1)</code>
+                      <code>  (typedef-4.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -204588,8 +204588,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-20.2">
-          <h3>38.8. The complex type <code>complexType[siri:AnnotatedLineStructure]/Directions#complexType (typedef-20.2)</code>
+        <div class="sect2" id="local-type.typedef-4.2">
+          <h3>38.8. The complex type <code>complexType[siri:AnnotatedLineStructure]/Directions#complexType (typedef-4.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -204609,7 +204609,7 @@
                       <br/>
                       <code>  /Directions #complexType</code>
                       <br/>
-                      <code>  (typedef-20.2)</code>
+                      <code>  (typedef-4.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -204651,8 +204651,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-20.3">
-          <h3>38.9. The complex type <code>complexType[siri:RouteDirectionStructure]/JourneyPatterns#complexType (typedef-20.3)</code>
+        <div class="sect2" id="local-type.typedef-4.3">
+          <h3>38.9. The complex type <code>complexType[siri:RouteDirectionStructure]/JourneyPatterns#complexType (typedef-4.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -204672,7 +204672,7 @@
                       <br/>
                       <code>  /JourneyPatterns #complexType</code>
                       <br/>
-                      <code>  (typedef-20.3)</code>
+                      <code>  (typedef-4.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -204702,7 +204702,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-20.4" title="local-type: typedef-20.4">local-type: typedef-20.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-4.4" title="local-type: typedef-4.4">local-type: typedef-4.4</a>
                       </em>
                     </p>
                   </td>
@@ -204714,8 +204714,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-20.4">
-          <h3>38.10. The complex type <code>complexType[siri:RouteDirectionStructure]/JourneyPatterns/JourneyPattern#complexType (typedef-20.4)</code>
+        <div class="sect2" id="local-type.typedef-4.4">
+          <h3>38.10. The complex type <code>complexType[siri:RouteDirectionStructure]/JourneyPatterns/JourneyPattern#complexType (typedef-4.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -204735,7 +204735,7 @@
                       <br/>
                       <code>  /JourneyPatterns/JourneyPattern #complexType</code>
                       <br/>
-                      <code>  (typedef-20.4)</code>
+                      <code>  (typedef-4.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -204810,7 +204810,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-20.5" title="local-type: typedef-20.5">local-type: typedef-20.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-4.5" title="local-type: typedef-4.5">local-type: typedef-4.5</a>
                       </em>
                     </p>
                   </td>
@@ -204822,8 +204822,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-20.5">
-          <h3>38.11. The complex type <code>complexType[siri:RouteDirectionStructure]/JourneyPatterns/JourneyPattern/StopsInPattern#complexType (typedef-20.5)</code>
+        <div class="sect2" id="local-type.typedef-4.5">
+          <h3>38.11. The complex type <code>complexType[siri:RouteDirectionStructure]/JourneyPatterns/JourneyPattern/StopsInPattern#complexType (typedef-4.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -204843,7 +204843,7 @@
                       <br/>
                       <code>  /JourneyPatterns/JourneyPattern/StopsInPattern #complexType</code>
                       <br/>
-                      <code>  (typedef-20.5)</code>
+                      <code>  (typedef-4.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -204885,8 +204885,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.1">
-          <h3>38.12. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Features#complexType (typedef-22.1)</code>
+        <div class="sect2" id="local-type.typedef-2.1">
+          <h3>38.12. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Features#complexType (typedef-2.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -204906,7 +204906,7 @@
                       <br/>
                       <code>  /Features #complexType</code>
                       <br/>
-                      <code>  (typedef-22.1)</code>
+                      <code>  (typedef-2.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -204992,8 +204992,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.2">
-          <h3>38.13. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Lines#complexType (typedef-22.2)</code>
+        <div class="sect2" id="local-type.typedef-2.2">
+          <h3>38.13. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Lines#complexType (typedef-2.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -205013,7 +205013,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-22.2)</code>
+                      <code>  (typedef-2.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -205301,7 +205301,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.1" title="local-type: typedef-22.1">local-type: typedef-22.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-2.1" title="local-type: typedef-2.1">local-type: typedef-2.1</a>
                       </em>
                     </p>
                   </td>
@@ -205325,7 +205325,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-22.2" title="local-type: typedef-22.2">local-type: typedef-22.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-2.2" title="local-type: typedef-2.2">local-type: typedef-2.2</a>
                       </em>
                     </p>
                   </td>
@@ -205384,8 +205384,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.1">
-          <h3>39.3. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Features#complexType (typedef-22.1)</code>
+        <div class="sect2" id="local-type.typedef-2.1">
+          <h3>39.3. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Features#complexType (typedef-2.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -205405,7 +205405,7 @@
                       <br/>
                       <code>  /Features #complexType</code>
                       <br/>
-                      <code>  (typedef-22.1)</code>
+                      <code>  (typedef-2.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -205491,8 +205491,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-22.2">
-          <h3>39.4. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Lines#complexType (typedef-22.2)</code>
+        <div class="sect2" id="local-type.typedef-2.2">
+          <h3>39.4. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Lines#complexType (typedef-2.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -205512,7 +205512,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-22.2)</code>
+                      <code>  (typedef-2.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -206636,7 +206636,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-84.1" title="local-type: typedef-84.1">local-type: typedef-84.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-78.1" title="local-type: typedef-78.1">local-type: typedef-78.1</a>
                       </em>
                     </p>
                   </td>
@@ -206786,7 +206786,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-84.2" title="local-type: typedef-84.2">local-type: typedef-84.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-78.2" title="local-type: typedef-78.2">local-type: typedef-78.2</a>
                       </em>
                     </p>
                   </td>
@@ -206838,7 +206838,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-84.3" title="local-type: typedef-84.3">local-type: typedef-84.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-78.3" title="local-type: typedef-78.3">local-type: typedef-78.3</a>
                       </em>
                     </p>
                   </td>
@@ -207898,7 +207898,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-84.7" title="local-type: typedef-84.7">local-type: typedef-84.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-78.7" title="local-type: typedef-78.7">local-type: typedef-78.7</a>
                       </em>
                     </p>
                   </td>
@@ -208808,7 +208808,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-84.1" title="local-type: typedef-84.1">local-type: typedef-84.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-78.1" title="local-type: typedef-78.1">local-type: typedef-78.1</a>
                       </em>
                     </p>
                   </td>
@@ -209139,7 +209139,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-84.4" title="local-type: typedef-84.4">local-type: typedef-84.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-78.4" title="local-type: typedef-78.4">local-type: typedef-78.4</a>
                       </em>
                     </p>
                   </td>
@@ -209163,7 +209163,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-84.5" title="local-type: typedef-84.5">local-type: typedef-84.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-78.5" title="local-type: typedef-78.5">local-type: typedef-78.5</a>
                       </em>
                     </p>
                   </td>
@@ -209187,7 +209187,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-84.6" title="local-type: typedef-84.6">local-type: typedef-84.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-78.6" title="local-type: typedef-78.6">local-type: typedef-78.6</a>
                       </em>
                     </p>
                   </td>
@@ -209559,8 +209559,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-84.3">
-          <h3>40.23. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-84.3)</code>
+        <div class="sect2" id="local-type.typedef-78.3">
+          <h3>40.23. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-78.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -209580,7 +209580,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-84.3)</code>
+                      <code>  (typedef-78.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -209730,8 +209730,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-84.7">
-          <h3>40.24. The complex type <code>element[siri:ProductionTimetablePermissions]#complexType (typedef-84.7)</code>
+        <div class="sect2" id="local-type.typedef-78.7">
+          <h3>40.24. The complex type <code>element[siri:ProductionTimetablePermissions]#complexType (typedef-78.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -209751,7 +209751,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-84.7)</code>
+                      <code>  (typedef-78.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -209826,8 +209826,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-84.2">
-          <h3>40.25. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-84.2)</code>
+        <div class="sect2" id="local-type.typedef-78.2">
+          <h3>40.25. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-78.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -209847,7 +209847,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-84.2)</code>
+                      <code>  (typedef-78.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -210044,8 +210044,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-84.1">
-          <h3>40.26. The complex type <code>group[siri:ProductionTimetableTopicGroup]/Lines#complexType (typedef-84.1)</code>
+        <div class="sect2" id="local-type.typedef-78.1">
+          <h3>40.26. The complex type <code>group[siri:ProductionTimetableTopicGroup]/Lines#complexType (typedef-78.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -210065,7 +210065,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-84.1)</code>
+                      <code>  (typedef-78.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -210107,8 +210107,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-84.2">
-          <h3>40.27. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-84.2)</code>
+        <div class="sect2" id="local-type.typedef-78.2">
+          <h3>40.27. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-78.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -210128,7 +210128,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-84.2)</code>
+                      <code>  (typedef-78.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -210325,8 +210325,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-84.3">
-          <h3>40.28. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-84.3)</code>
+        <div class="sect2" id="local-type.typedef-78.3">
+          <h3>40.28. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-78.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -210346,7 +210346,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-84.3)</code>
+                      <code>  (typedef-78.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -210496,8 +210496,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-84.7">
-          <h3>40.29. The complex type <code>element[siri:ProductionTimetablePermissions]#complexType (typedef-84.7)</code>
+        <div class="sect2" id="local-type.typedef-78.7">
+          <h3>40.29. The complex type <code>element[siri:ProductionTimetablePermissions]#complexType (typedef-78.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -210517,7 +210517,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-84.7)</code>
+                      <code>  (typedef-78.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -210592,8 +210592,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-84.1">
-          <h3>40.30. The complex type <code>group[siri:ProductionTimetableTopicGroup]/Lines#complexType (typedef-84.1)</code>
+        <div class="sect2" id="local-type.typedef-78.1">
+          <h3>40.30. The complex type <code>group[siri:ProductionTimetableTopicGroup]/Lines#complexType (typedef-78.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -210613,7 +210613,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-84.1)</code>
+                      <code>  (typedef-78.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -210655,8 +210655,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-84.4">
-          <h3>40.31. The complex type <code>complexType[siri:ProductionTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-84.4)</code>
+        <div class="sect2" id="local-type.typedef-78.4">
+          <h3>40.31. The complex type <code>complexType[siri:ProductionTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-78.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -210676,7 +210676,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-84.4)</code>
+                      <code>  (typedef-78.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -210873,8 +210873,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-84.5">
-          <h3>40.32. The complex type <code>complexType[siri:ProductionTimetableServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-84.5)</code>
+        <div class="sect2" id="local-type.typedef-78.5">
+          <h3>40.32. The complex type <code>complexType[siri:ProductionTimetableServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-78.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -210894,7 +210894,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-84.5)</code>
+                      <code>  (typedef-78.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -211038,8 +211038,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-84.6">
-          <h3>40.33. The complex type <code>complexType[siri:ProductionTimetableServiceCapabilitiesStructure]/SubscriptionPolicy#complexType (typedef-84.6)</code>
+        <div class="sect2" id="local-type.typedef-78.6">
+          <h3>40.33. The complex type <code>complexType[siri:ProductionTimetableServiceCapabilitiesStructure]/SubscriptionPolicy#complexType (typedef-78.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -211059,7 +211059,7 @@
                       <br/>
                       <code>  /SubscriptionPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-84.6)</code>
+                      <code>  (typedef-78.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -211774,7 +211774,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.3" title="local-type: typedef-75.3">local-type: typedef-75.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.3" title="local-type: typedef-73.3">local-type: typedef-73.3</a>
                       </em>
                     </p>
                   </td>
@@ -212640,7 +212640,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.2" title="local-type: typedef-75.2">local-type: typedef-75.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.2" title="local-type: typedef-73.2">local-type: typedef-73.2</a>
                       </em>
                     </p>
                   </td>
@@ -212953,7 +212953,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.1" title="local-type: typedef-75.1">local-type: typedef-75.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.1" title="local-type: typedef-73.1">local-type: typedef-73.1</a>
                       </em>
                     </p>
                   </td>
@@ -213327,7 +213327,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.2" title="local-type: typedef-75.2">local-type: typedef-75.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.2" title="local-type: typedef-73.2">local-type: typedef-73.2</a>
                       </em>
                     </p>
                   </td>
@@ -214492,7 +214492,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.8" title="local-type: typedef-75.8">local-type: typedef-75.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.8" title="local-type: typedef-73.8">local-type: typedef-73.8</a>
                       </em>
                     </p>
                   </td>
@@ -215000,7 +215000,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.3" title="local-type: typedef-75.3">local-type: typedef-75.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.3" title="local-type: typedef-73.3">local-type: typedef-73.3</a>
                       </em>
                     </p>
                   </td>
@@ -215835,7 +215835,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.2" title="local-type: typedef-75.2">local-type: typedef-75.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.2" title="local-type: typedef-73.2">local-type: typedef-73.2</a>
                       </em>
                     </p>
                   </td>
@@ -216148,7 +216148,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.1" title="local-type: typedef-75.1">local-type: typedef-75.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.1" title="local-type: typedef-73.1">local-type: typedef-73.1</a>
                       </em>
                     </p>
                   </td>
@@ -216373,7 +216373,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.4" title="local-type: typedef-75.4">local-type: typedef-75.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.4" title="local-type: typedef-73.4">local-type: typedef-73.4</a>
                       </em>
                     </p>
                   </td>
@@ -216397,7 +216397,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.5" title="local-type: typedef-75.5">local-type: typedef-75.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.5" title="local-type: typedef-73.5">local-type: typedef-73.5</a>
                       </em>
                     </p>
                   </td>
@@ -216445,7 +216445,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.6" title="local-type: typedef-75.6">local-type: typedef-75.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.6" title="local-type: typedef-73.6">local-type: typedef-73.6</a>
                       </em>
                     </p>
                   </td>
@@ -216469,7 +216469,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.7" title="local-type: typedef-75.7">local-type: typedef-75.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.7" title="local-type: typedef-73.7">local-type: typedef-73.7</a>
                       </em>
                     </p>
                   </td>
@@ -216628,7 +216628,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-13.1" title="local-type: typedef-13.1">local-type: typedef-13.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
                       </em>
                     </p>
                   </td>
@@ -216662,7 +216662,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-43.2" title="local-type: typedef-43.2">local-type: typedef-43.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-56.2" title="local-type: typedef-56.2">local-type: typedef-56.2</a>
                       </em>
                     </p>
                   </td>
@@ -216691,7 +216691,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-43.1" title="local-type: typedef-43.1">local-type: typedef-43.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-56.1" title="local-type: typedef-56.1">local-type: typedef-56.1</a>
                       </em>
                     </p>
                   </td>
@@ -216947,8 +216947,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.8">
-          <h3>41.33. The complex type <code>element[siri:SituationExchangePermissions]#complexType (typedef-75.8)</code>
+        <div class="sect2" id="local-type.typedef-73.8">
+          <h3>41.33. The complex type <code>element[siri:SituationExchangePermissions]#complexType (typedef-73.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -216968,7 +216968,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-75.8)</code>
+                      <code>  (typedef-73.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -217042,8 +217042,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.3">
-          <h3>41.34. The complex type <code>group[siri:SituationExchangePayloadGroup]/Situations#complexType (typedef-75.3)</code>
+        <div class="sect2" id="local-type.typedef-73.3">
+          <h3>41.34. The complex type <code>group[siri:SituationExchangePayloadGroup]/Situations#complexType (typedef-73.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -217063,7 +217063,7 @@
                       <br/>
                       <code>  /Situations #complexType</code>
                       <br/>
-                      <code>  (typedef-75.3)</code>
+                      <code>  (typedef-73.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -217126,8 +217126,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.2">
-          <h3>41.35. The complex type <code>group[siri:SituationNetworkFilterGroup]/Lines#complexType (typedef-75.2)</code>
+        <div class="sect2" id="local-type.typedef-73.2">
+          <h3>41.35. The complex type <code>group[siri:SituationNetworkFilterGroup]/Lines#complexType (typedef-73.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -217147,7 +217147,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-75.2)</code>
+                      <code>  (typedef-73.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -217189,8 +217189,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.1">
-          <h3>41.36. The complex type <code>group[siri:SituationExchangeTopicGroup]/SituationRoadFilter#complexType (typedef-75.1)</code>
+        <div class="sect2" id="local-type.typedef-73.1">
+          <h3>41.36. The complex type <code>group[siri:SituationExchangeTopicGroup]/SituationRoadFilter#complexType (typedef-73.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -217210,7 +217210,7 @@
                       <br/>
                       <code>  /SituationRoadFilter #complexType</code>
                       <br/>
-                      <code>  (typedef-75.1)</code>
+                      <code>  (typedef-73.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -217252,8 +217252,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.2">
-          <h3>41.37. The complex type <code>group[siri:SituationNetworkFilterGroup]/Lines#complexType (typedef-75.2)</code>
+        <div class="sect2" id="local-type.typedef-73.2">
+          <h3>41.37. The complex type <code>group[siri:SituationNetworkFilterGroup]/Lines#complexType (typedef-73.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -217273,7 +217273,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-75.2)</code>
+                      <code>  (typedef-73.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -217315,8 +217315,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.8">
-          <h3>41.38. The complex type <code>element[siri:SituationExchangePermissions]#complexType (typedef-75.8)</code>
+        <div class="sect2" id="local-type.typedef-73.8">
+          <h3>41.38. The complex type <code>element[siri:SituationExchangePermissions]#complexType (typedef-73.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -217336,7 +217336,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-75.8)</code>
+                      <code>  (typedef-73.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -217410,8 +217410,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.3">
-          <h3>41.39. The complex type <code>group[siri:SituationExchangePayloadGroup]/Situations#complexType (typedef-75.3)</code>
+        <div class="sect2" id="local-type.typedef-73.3">
+          <h3>41.39. The complex type <code>group[siri:SituationExchangePayloadGroup]/Situations#complexType (typedef-73.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -217431,7 +217431,7 @@
                       <br/>
                       <code>  /Situations #complexType</code>
                       <br/>
-                      <code>  (typedef-75.3)</code>
+                      <code>  (typedef-73.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -217494,8 +217494,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.2">
-          <h3>41.40. The complex type <code>group[siri:SituationNetworkFilterGroup]/Lines#complexType (typedef-75.2)</code>
+        <div class="sect2" id="local-type.typedef-73.2">
+          <h3>41.40. The complex type <code>group[siri:SituationNetworkFilterGroup]/Lines#complexType (typedef-73.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -217515,7 +217515,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-75.2)</code>
+                      <code>  (typedef-73.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -217557,8 +217557,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.1">
-          <h3>41.41. The complex type <code>group[siri:SituationExchangeTopicGroup]/SituationRoadFilter#complexType (typedef-75.1)</code>
+        <div class="sect2" id="local-type.typedef-73.1">
+          <h3>41.41. The complex type <code>group[siri:SituationExchangeTopicGroup]/SituationRoadFilter#complexType (typedef-73.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -217578,7 +217578,7 @@
                       <br/>
                       <code>  /SituationRoadFilter #complexType</code>
                       <br/>
-                      <code>  (typedef-75.1)</code>
+                      <code>  (typedef-73.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -217620,8 +217620,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.4">
-          <h3>41.42. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-75.4)</code>
+        <div class="sect2" id="local-type.typedef-73.4">
+          <h3>41.42. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-73.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -217641,7 +217641,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-75.4)</code>
+                      <code>  (typedef-73.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -217990,8 +217990,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.5">
-          <h3>41.43. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-75.5)</code>
+        <div class="sect2" id="local-type.typedef-73.5">
+          <h3>41.43. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-73.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -218011,7 +218011,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-75.5)</code>
+                      <code>  (typedef-73.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -218183,8 +218183,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.6">
-          <h3>41.44. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/AccessControl#complexType (typedef-75.6)</code>
+        <div class="sect2" id="local-type.typedef-73.6">
+          <h3>41.44. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/AccessControl#complexType (typedef-73.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -218204,7 +218204,7 @@
                       <br/>
                       <code>  /AccessControl #complexType</code>
                       <br/>
-                      <code>  (typedef-75.6)</code>
+                      <code>  (typedef-73.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -218305,8 +218305,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.7">
-          <h3>41.45. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-75.7)</code>
+        <div class="sect2" id="local-type.typedef-73.7">
+          <h3>41.45. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-73.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -218326,7 +218326,7 @@
                       <br/>
                       <code>  /ResponseFeatures #complexType</code>
                       <br/>
-                      <code>  (typedef-75.7)</code>
+                      <code>  (typedef-73.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -218340,8 +218340,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-13.1">
-          <h3>41.46. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-13.1)</code>
+        <div class="sect2" id="local-type.typedef-36.1">
+          <h3>41.46. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-36.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -218361,7 +218361,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-13.1)</code>
+                      <code>  (typedef-36.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -218429,8 +218429,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-43.2">
-          <h3>41.47. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-43.2)</code>
+        <div class="sect2" id="local-type.typedef-56.2">
+          <h3>41.47. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-56.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -218450,7 +218450,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-43.2)</code>
+                      <code>  (typedef-56.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -218535,8 +218535,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-43.1">
-          <h3>41.48. The complex type <code>element[siri:LinePermissions]#complexType (typedef-43.1)</code>
+        <div class="sect2" id="local-type.typedef-56.1">
+          <h3>41.48. The complex type <code>element[siri:LinePermissions]#complexType (typedef-56.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -218556,7 +218556,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-43.1)</code>
+                      <code>  (typedef-56.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -220091,7 +220091,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.1" title="local-type: typedef-77.1">local-type: typedef-77.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.1" title="local-type: typedef-80.1">local-type: typedef-80.1</a>
                       </em>
                     </p>
                   </td>
@@ -222644,7 +222644,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.5" title="local-type: typedef-77.5">local-type: typedef-77.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.5" title="local-type: typedef-80.5">local-type: typedef-80.5</a>
                       </em>
                     </p>
                   </td>
@@ -223976,7 +223976,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.1" title="local-type: typedef-77.1">local-type: typedef-77.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.1" title="local-type: typedef-80.1">local-type: typedef-80.1</a>
                       </em>
                     </p>
                   </td>
@@ -224655,7 +224655,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.1" title="local-type: typedef-77.1">local-type: typedef-77.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.1" title="local-type: typedef-80.1">local-type: typedef-80.1</a>
                       </em>
                     </p>
                   </td>
@@ -224795,7 +224795,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.2" title="local-type: typedef-80.2">local-type: typedef-80.2</a>
                       </em>
                     </p>
                   </td>
@@ -224819,7 +224819,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.3" title="local-type: typedef-77.3">local-type: typedef-77.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.3" title="local-type: typedef-80.3">local-type: typedef-80.3</a>
                       </em>
                     </p>
                   </td>
@@ -224891,7 +224891,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.4" title="local-type: typedef-77.4">local-type: typedef-77.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.4" title="local-type: typedef-80.4">local-type: typedef-80.4</a>
                       </em>
                     </p>
                   </td>
@@ -225025,7 +225025,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-13.1" title="local-type: typedef-13.1">local-type: typedef-13.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
                       </em>
                     </p>
                   </td>
@@ -225059,7 +225059,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-43.2" title="local-type: typedef-43.2">local-type: typedef-43.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-56.2" title="local-type: typedef-56.2">local-type: typedef-56.2</a>
                       </em>
                     </p>
                   </td>
@@ -225088,7 +225088,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-43.1" title="local-type: typedef-43.1">local-type: typedef-43.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-56.1" title="local-type: typedef-56.1">local-type: typedef-56.1</a>
                       </em>
                     </p>
                   </td>
@@ -225116,7 +225116,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.6" title="local-type: typedef-77.6">local-type: typedef-77.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.6" title="local-type: typedef-80.6">local-type: typedef-80.6</a>
                       </em>
                     </p>
                   </td>
@@ -225819,8 +225819,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.5">
-          <h3>42.47. The complex type <code>element[siri:StopMonitoringPermissions]#complexType (typedef-77.5)</code>
+        <div class="sect2" id="local-type.typedef-80.5">
+          <h3>42.47. The complex type <code>element[siri:StopMonitoringPermissions]#complexType (typedef-80.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -225840,7 +225840,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.5)</code>
+                      <code>  (typedef-80.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -225914,8 +225914,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.1">
-          <h3>42.48. The complex type <code>group[siri:StopMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-77.1)</code>
+        <div class="sect2" id="local-type.typedef-80.1">
+          <h3>42.48. The complex type <code>group[siri:StopMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-80.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -225935,7 +225935,7 @@
                       <br/>
                       <code>  /MaximumNumberOfCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-77.1)</code>
+                      <code>  (typedef-80.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -225995,8 +225995,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.5">
-          <h3>42.49. The complex type <code>element[siri:StopMonitoringPermissions]#complexType (typedef-77.5)</code>
+        <div class="sect2" id="local-type.typedef-80.5">
+          <h3>42.49. The complex type <code>element[siri:StopMonitoringPermissions]#complexType (typedef-80.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -226016,7 +226016,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.5)</code>
+                      <code>  (typedef-80.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -226090,8 +226090,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.1">
-          <h3>42.50. The complex type <code>group[siri:StopMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-77.1)</code>
+        <div class="sect2" id="local-type.typedef-80.1">
+          <h3>42.50. The complex type <code>group[siri:StopMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-80.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -226111,7 +226111,7 @@
                       <br/>
                       <code>  /MaximumNumberOfCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-77.1)</code>
+                      <code>  (typedef-80.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -226171,8 +226171,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.1">
-          <h3>42.51. The complex type <code>group[siri:StopMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-77.1)</code>
+        <div class="sect2" id="local-type.typedef-80.1">
+          <h3>42.51. The complex type <code>group[siri:StopMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-80.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -226192,7 +226192,7 @@
                       <br/>
                       <code>  /MaximumNumberOfCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-77.1)</code>
+                      <code>  (typedef-80.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -226252,8 +226252,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.2">
-          <h3>42.52. The complex type <code>complexType[siri:StopMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-77.2)</code>
+        <div class="sect2" id="local-type.typedef-80.2">
+          <h3>42.52. The complex type <code>complexType[siri:StopMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-80.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -226273,7 +226273,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-77.2)</code>
+                      <code>  (typedef-80.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -226466,8 +226466,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.3">
-          <h3>42.53. The complex type <code>complexType[siri:StopMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-77.3)</code>
+        <div class="sect2" id="local-type.typedef-80.3">
+          <h3>42.53. The complex type <code>complexType[siri:StopMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-80.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -226487,7 +226487,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-77.3)</code>
+                      <code>  (typedef-80.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -226827,8 +226827,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.4">
-          <h3>42.54. The complex type <code>complexType[siri:StopMonitoringServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-77.4)</code>
+        <div class="sect2" id="local-type.typedef-80.4">
+          <h3>42.54. The complex type <code>complexType[siri:StopMonitoringServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-80.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -226848,7 +226848,7 @@
                       <br/>
                       <code>  /ResponseFeatures #complexType</code>
                       <br/>
-                      <code>  (typedef-77.4)</code>
+                      <code>  (typedef-80.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -226908,8 +226908,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-13.1">
-          <h3>42.55. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-13.1)</code>
+        <div class="sect2" id="local-type.typedef-36.1">
+          <h3>42.55. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-36.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -226929,7 +226929,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-13.1)</code>
+                      <code>  (typedef-36.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -226997,8 +226997,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-43.2">
-          <h3>42.56. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-43.2)</code>
+        <div class="sect2" id="local-type.typedef-56.2">
+          <h3>42.56. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-56.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -227018,7 +227018,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-43.2)</code>
+                      <code>  (typedef-56.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -227103,8 +227103,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-43.1">
-          <h3>42.57. The complex type <code>element[siri:LinePermissions]#complexType (typedef-43.1)</code>
+        <div class="sect2" id="local-type.typedef-56.1">
+          <h3>42.57. The complex type <code>element[siri:LinePermissions]#complexType (typedef-56.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -227124,7 +227124,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-43.1)</code>
+                      <code>  (typedef-56.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -227209,8 +227209,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.6">
-          <h3>42.58. The complex type <code>complexType[siri:StopMonitoringServicePermissionStructure]/StopMonitorPermissions#complexType (typedef-77.6)</code>
+        <div class="sect2" id="local-type.typedef-80.6">
+          <h3>42.58. The complex type <code>complexType[siri:StopMonitoringServicePermissionStructure]/StopMonitorPermissions#complexType (typedef-80.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -227230,7 +227230,7 @@
                       <br/>
                       <code>  /StopMonitorPermissions #complexType</code>
                       <br/>
-                      <code>  (typedef-77.6)</code>
+                      <code>  (typedef-80.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -228374,7 +228374,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.3" title="local-type: typedef-79.3">local-type: typedef-79.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-81.3" title="local-type: typedef-81.3">local-type: typedef-81.3</a>
                       </em>
                     </p>
                   </td>
@@ -229518,7 +229518,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.1" title="local-type: typedef-79.1">local-type: typedef-79.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-81.1" title="local-type: typedef-81.1">local-type: typedef-81.1</a>
                       </em>
                     </p>
                   </td>
@@ -229566,7 +229566,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.2" title="local-type: typedef-79.2">local-type: typedef-79.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-81.2" title="local-type: typedef-81.2">local-type: typedef-81.2</a>
                       </em>
                     </p>
                   </td>
@@ -229725,7 +229725,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-13.1" title="local-type: typedef-13.1">local-type: typedef-13.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
                       </em>
                     </p>
                   </td>
@@ -229759,7 +229759,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-43.2" title="local-type: typedef-43.2">local-type: typedef-43.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-56.2" title="local-type: typedef-56.2">local-type: typedef-56.2</a>
                       </em>
                     </p>
                   </td>
@@ -229788,7 +229788,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-43.1" title="local-type: typedef-43.1">local-type: typedef-43.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-56.1" title="local-type: typedef-56.1">local-type: typedef-56.1</a>
                       </em>
                     </p>
                   </td>
@@ -229816,7 +229816,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.4" title="local-type: typedef-79.4">local-type: typedef-79.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-81.4" title="local-type: typedef-81.4">local-type: typedef-81.4</a>
                       </em>
                     </p>
                   </td>
@@ -230772,8 +230772,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.3">
-          <h3>43.23. The complex type <code>element[siri:StopTimetablePermissions]#complexType (typedef-79.3)</code>
+        <div class="sect2" id="local-type.typedef-81.3">
+          <h3>43.23. The complex type <code>element[siri:StopTimetablePermissions]#complexType (typedef-81.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -230793,7 +230793,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-79.3)</code>
+                      <code>  (typedef-81.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -230867,8 +230867,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.3">
-          <h3>43.24. The complex type <code>element[siri:StopTimetablePermissions]#complexType (typedef-79.3)</code>
+        <div class="sect2" id="local-type.typedef-81.3">
+          <h3>43.24. The complex type <code>element[siri:StopTimetablePermissions]#complexType (typedef-81.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -230888,7 +230888,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-79.3)</code>
+                      <code>  (typedef-81.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -230962,8 +230962,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.1">
-          <h3>43.25. The complex type <code>complexType[siri:StopTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-79.1)</code>
+        <div class="sect2" id="local-type.typedef-81.1">
+          <h3>43.25. The complex type <code>complexType[siri:StopTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-81.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -230983,7 +230983,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-79.1)</code>
+                      <code>  (typedef-81.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -231077,8 +231077,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.2">
-          <h3>43.26. The complex type <code>complexType[siri:StopTimetableServiceCapabilitiesStructure]/AccessControl#complexType (typedef-79.2)</code>
+        <div class="sect2" id="local-type.typedef-81.2">
+          <h3>43.26. The complex type <code>complexType[siri:StopTimetableServiceCapabilitiesStructure]/AccessControl#complexType (typedef-81.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -231098,7 +231098,7 @@
                       <br/>
                       <code>  /AccessControl #complexType</code>
                       <br/>
-                      <code>  (typedef-79.2)</code>
+                      <code>  (typedef-81.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -231223,8 +231223,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-13.1">
-          <h3>43.27. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-13.1)</code>
+        <div class="sect2" id="local-type.typedef-36.1">
+          <h3>43.27. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-36.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -231244,7 +231244,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-13.1)</code>
+                      <code>  (typedef-36.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -231312,8 +231312,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-43.2">
-          <h3>43.28. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-43.2)</code>
+        <div class="sect2" id="local-type.typedef-56.2">
+          <h3>43.28. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-56.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -231333,7 +231333,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-43.2)</code>
+                      <code>  (typedef-56.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -231418,8 +231418,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-43.1">
-          <h3>43.29. The complex type <code>element[siri:LinePermissions]#complexType (typedef-43.1)</code>
+        <div class="sect2" id="local-type.typedef-56.1">
+          <h3>43.29. The complex type <code>element[siri:LinePermissions]#complexType (typedef-56.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -231439,7 +231439,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-43.1)</code>
+                      <code>  (typedef-56.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -231524,8 +231524,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.4">
-          <h3>43.30. The complex type <code>complexType[siri:StopTimetableServicePermissionStructure]/StopMonitorPermissions#complexType (typedef-79.4)</code>
+        <div class="sect2" id="local-type.typedef-81.4">
+          <h3>43.30. The complex type <code>complexType[siri:StopTimetableServicePermissionStructure]/StopMonitorPermissions#complexType (typedef-81.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -231545,7 +231545,7 @@
                       <br/>
                       <code>  /StopMonitorPermissions #complexType</code>
                       <br/>
-                      <code>  (typedef-79.4)</code>
+                      <code>  (typedef-81.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -232946,7 +232946,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-13.1" title="local-type: typedef-13.1">local-type: typedef-13.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
                       </em>
                     </p>
                   </td>
@@ -233074,8 +233074,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-13.1">
-          <h3>46.5. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-13.1)</code>
+        <div class="sect2" id="local-type.typedef-36.1">
+          <h3>46.5. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-36.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -233095,7 +233095,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-13.1)</code>
+                      <code>  (typedef-36.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -233358,12 +233358,12 @@
                 </tr>
                 <tr>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-12.1" class="tableblock">
+                    <p id="local-type.typedef-24.1" class="tableblock">
                       <code>attribute[lang]</code>
                       <br/>
                       <code>  #simpleType</code>
                       <br/>
-                      <code>  (typedef-12.1)</code>
+                      <code>  (typedef-24.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -235637,7 +235637,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.1" title="local-type: typedef-80.1">local-type: typedef-80.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.1" title="local-type: typedef-79.1">local-type: typedef-79.1</a>
                       </em>
                     </p>
                   </td>
@@ -236760,7 +236760,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.2" title="local-type: typedef-80.2">local-type: typedef-80.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.2" title="local-type: typedef-79.2">local-type: typedef-79.2</a>
                       </em>
                     </p>
                   </td>
@@ -237074,7 +237074,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.7" title="local-type: typedef-80.7">local-type: typedef-80.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.7" title="local-type: typedef-79.7">local-type: typedef-79.7</a>
                       </em>
                     </p>
                   </td>
@@ -238214,7 +238214,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.1" title="local-type: typedef-80.1">local-type: typedef-80.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.1" title="local-type: typedef-79.1">local-type: typedef-79.1</a>
                       </em>
                     </p>
                   </td>
@@ -238374,7 +238374,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.3" title="local-type: typedef-80.3">local-type: typedef-80.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.3" title="local-type: typedef-79.3">local-type: typedef-79.3</a>
                       </em>
                     </p>
                   </td>
@@ -238398,7 +238398,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.4" title="local-type: typedef-80.4">local-type: typedef-80.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.4" title="local-type: typedef-79.4">local-type: typedef-79.4</a>
                       </em>
                     </p>
                   </td>
@@ -238446,7 +238446,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.5" title="local-type: typedef-80.5">local-type: typedef-80.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.5" title="local-type: typedef-79.5">local-type: typedef-79.5</a>
                       </em>
                     </p>
                   </td>
@@ -238470,7 +238470,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.6" title="local-type: typedef-80.6">local-type: typedef-80.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.6" title="local-type: typedef-79.6">local-type: typedef-79.6</a>
                       </em>
                     </p>
                   </td>
@@ -238629,7 +238629,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-13.1" title="local-type: typedef-13.1">local-type: typedef-13.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
                       </em>
                     </p>
                   </td>
@@ -238663,7 +238663,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-43.2" title="local-type: typedef-43.2">local-type: typedef-43.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-56.2" title="local-type: typedef-56.2">local-type: typedef-56.2</a>
                       </em>
                     </p>
                   </td>
@@ -238692,7 +238692,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-43.1" title="local-type: typedef-43.1">local-type: typedef-43.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-56.1" title="local-type: typedef-56.1">local-type: typedef-56.1</a>
                       </em>
                     </p>
                   </td>
@@ -238720,7 +238720,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.8" title="local-type: typedef-80.8">local-type: typedef-80.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.8" title="local-type: typedef-79.8">local-type: typedef-79.8</a>
                       </em>
                     </p>
                   </td>
@@ -239133,8 +239133,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.7">
-          <h3>49.30. The complex type <code>element[siri:VehicleMonitoringPermissions]#complexType (typedef-80.7)</code>
+        <div class="sect2" id="local-type.typedef-79.7">
+          <h3>49.30. The complex type <code>element[siri:VehicleMonitoringPermissions]#complexType (typedef-79.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -239154,7 +239154,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-80.7)</code>
+                      <code>  (typedef-79.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -239228,8 +239228,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.1">
-          <h3>49.31. The complex type <code>group[siri:VehicleMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-80.1)</code>
+        <div class="sect2" id="local-type.typedef-79.1">
+          <h3>49.31. The complex type <code>group[siri:VehicleMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-79.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -239249,7 +239249,7 @@
                       <br/>
                       <code>  /MaximumNumberOfCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-80.1)</code>
+                      <code>  (typedef-79.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -239309,8 +239309,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.2">
-          <h3>49.32. The complex type <code>complexType[siri:VehicleActivityStructure]/MonitoredVehicleJourney#complexType (typedef-80.2)</code>
+        <div class="sect2" id="local-type.typedef-79.2">
+          <h3>49.32. The complex type <code>complexType[siri:VehicleActivityStructure]/MonitoredVehicleJourney#complexType (typedef-79.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -239330,7 +239330,7 @@
                       <br/>
                       <code>  /MonitoredVehicleJourney #complexType</code>
                       <br/>
-                      <code>  (typedef-80.2)</code>
+                      <code>  (typedef-79.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -240776,7 +240776,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-55.4" title="local-type: typedef-55.4">local-type: typedef-55.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.4" title="local-type: typedef-57.4">local-type: typedef-57.4</a>
                       </em>
                     </p>
                   </td>
@@ -240797,7 +240797,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-55.5" title="local-type: typedef-55.5">local-type: typedef-55.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.5" title="local-type: typedef-57.5">local-type: typedef-57.5</a>
                       </em>
                     </p>
                   </td>
@@ -240821,7 +240821,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.2" title="local-type: typedef-51.2">local-type: typedef-51.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.2" title="local-type: typedef-50.2">local-type: typedef-50.2</a>
                       </em>
                     </p>
                   </td>
@@ -240842,7 +240842,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.3" title="local-type: typedef-51.3">local-type: typedef-51.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.3" title="local-type: typedef-50.3">local-type: typedef-50.3</a>
                       </em>
                     </p>
                   </td>
@@ -240863,7 +240863,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-51.4" title="local-type: typedef-51.4">local-type: typedef-51.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.4" title="local-type: typedef-50.4">local-type: typedef-50.4</a>
                       </em>
                     </p>
                   </td>
@@ -240961,8 +240961,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-55.4">
-          <h3>49.33. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-55.4)</code>
+        <div class="sect2" id="local-type.typedef-57.4">
+          <h3>49.33. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-57.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -240982,7 +240982,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-55.4)</code>
+                      <code>  (typedef-57.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -241024,8 +241024,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-55.5">
-          <h3>49.34. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-55.5)</code>
+        <div class="sect2" id="local-type.typedef-57.5">
+          <h3>49.34. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-57.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -241045,7 +241045,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-55.5)</code>
+                      <code>  (typedef-57.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -241087,8 +241087,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.2">
-          <h3>49.35. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-51.2)</code>
+        <div class="sect2" id="local-type.typedef-50.2">
+          <h3>49.35. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-50.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -241108,7 +241108,7 @@
                       <br/>
                       <code>  /TrainElements #complexType</code>
                       <br/>
-                      <code>  (typedef-51.2)</code>
+                      <code>  (typedef-50.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -241195,8 +241195,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.3">
-          <h3>49.36. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-51.3)</code>
+        <div class="sect2" id="local-type.typedef-50.3">
+          <h3>49.36. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-50.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -241216,7 +241216,7 @@
                       <br/>
                       <code>  /Trains #complexType</code>
                       <br/>
-                      <code>  (typedef-51.3)</code>
+                      <code>  (typedef-50.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -241303,8 +241303,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-51.4">
-          <h3>49.37. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-51.4)</code>
+        <div class="sect2" id="local-type.typedef-50.4">
+          <h3>49.37. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-50.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -241324,7 +241324,7 @@
                       <br/>
                       <code>  /CompoundTrains #complexType</code>
                       <br/>
-                      <code>  (typedef-51.4)</code>
+                      <code>  (typedef-50.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -241411,8 +241411,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.7">
-          <h3>49.38. The complex type <code>element[siri:VehicleMonitoringPermissions]#complexType (typedef-80.7)</code>
+        <div class="sect2" id="local-type.typedef-79.7">
+          <h3>49.38. The complex type <code>element[siri:VehicleMonitoringPermissions]#complexType (typedef-79.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -241432,7 +241432,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-80.7)</code>
+                      <code>  (typedef-79.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -241506,8 +241506,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.1">
-          <h3>49.39. The complex type <code>group[siri:VehicleMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-80.1)</code>
+        <div class="sect2" id="local-type.typedef-79.1">
+          <h3>49.39. The complex type <code>group[siri:VehicleMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-79.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -241527,7 +241527,7 @@
                       <br/>
                       <code>  /MaximumNumberOfCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-80.1)</code>
+                      <code>  (typedef-79.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -241587,8 +241587,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.3">
-          <h3>49.40. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-80.3)</code>
+        <div class="sect2" id="local-type.typedef-79.3">
+          <h3>49.40. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-79.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -241608,7 +241608,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-80.3)</code>
+                      <code>  (typedef-79.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -241750,8 +241750,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.4">
-          <h3>49.41. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-80.4)</code>
+        <div class="sect2" id="local-type.typedef-79.4">
+          <h3>49.41. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-79.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -241771,7 +241771,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-80.4)</code>
+                      <code>  (typedef-79.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -242045,8 +242045,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.5">
-          <h3>49.42. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/AccessControl#complexType (typedef-80.5)</code>
+        <div class="sect2" id="local-type.typedef-79.5">
+          <h3>49.42. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/AccessControl#complexType (typedef-79.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -242066,7 +242066,7 @@
                       <br/>
                       <code>  /AccessControl #complexType</code>
                       <br/>
-                      <code>  (typedef-80.5)</code>
+                      <code>  (typedef-79.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -242190,8 +242190,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.6">
-          <h3>49.43. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-80.6)</code>
+        <div class="sect2" id="local-type.typedef-79.6">
+          <h3>49.43. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-79.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -242211,7 +242211,7 @@
                       <br/>
                       <code>  /ResponseFeatures #complexType</code>
                       <br/>
-                      <code>  (typedef-80.6)</code>
+                      <code>  (typedef-79.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -242271,8 +242271,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-13.1">
-          <h3>49.44. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-13.1)</code>
+        <div class="sect2" id="local-type.typedef-36.1">
+          <h3>49.44. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-36.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -242292,7 +242292,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-13.1)</code>
+                      <code>  (typedef-36.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -242360,8 +242360,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-43.2">
-          <h3>49.45. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-43.2)</code>
+        <div class="sect2" id="local-type.typedef-56.2">
+          <h3>49.45. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-56.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -242381,7 +242381,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-43.2)</code>
+                      <code>  (typedef-56.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -242466,8 +242466,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-43.1">
-          <h3>49.46. The complex type <code>element[siri:LinePermissions]#complexType (typedef-43.1)</code>
+        <div class="sect2" id="local-type.typedef-56.1">
+          <h3>49.46. The complex type <code>element[siri:LinePermissions]#complexType (typedef-56.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -242487,7 +242487,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-43.1)</code>
+                      <code>  (typedef-56.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -242572,8 +242572,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.8">
-          <h3>49.47. The complex type <code>complexType[siri:VehicleMonitoringServicePermissionStructure]/VehicleMonitoringPermissions#complexType (typedef-80.8)</code>
+        <div class="sect2" id="local-type.typedef-79.8">
+          <h3>49.47. The complex type <code>complexType[siri:VehicleMonitoringServicePermissionStructure]/VehicleMonitoringPermissions#complexType (typedef-79.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -242593,7 +242593,7 @@
                       <br/>
                       <code>  /VehicleMonitoringPermissions #complexType</code>
                       <br/>
-                      <code>  (typedef-80.8)</code>
+                      <code>  (typedef-79.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -242776,7 +242776,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
                       </em>
                     </p>
                   </td>
@@ -242807,7 +242807,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-6.2" title="local-type: typedef-6.2">local-type: typedef-6.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-33.2" title="local-type: typedef-33.2">local-type: typedef-33.2</a>
                       </em>
                     </p>
                   </td>
@@ -243193,7 +243193,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.4" title="local-type: typedef-72.4">local-type: typedef-72.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.4" title="local-type: typedef-77.4">local-type: typedef-77.4</a>
                       </em>
                     </p>
                   </td>
@@ -243375,8 +243375,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-81.1">
-          <h3>50.2. The complex type <code>element[siri:Siri]#complexType (typedef-81.1)</code>
+        <div class="sect2" id="local-type.typedef-83.1">
+          <h3>50.2. The complex type <code>element[siri:Siri]#complexType (typedef-83.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -243396,7 +243396,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-81.1)</code>
+                      <code>  (typedef-83.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -243474,7 +243474,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
                       </em>
                     </p>
                   </td>
@@ -243505,7 +243505,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-6.2" title="local-type: typedef-6.2">local-type: typedef-6.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-33.2" title="local-type: typedef-33.2">local-type: typedef-33.2</a>
                       </em>
                     </p>
                   </td>
@@ -243891,7 +243891,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.4" title="local-type: typedef-72.4">local-type: typedef-72.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.4" title="local-type: typedef-77.4">local-type: typedef-77.4</a>
                       </em>
                     </p>
                   </td>
@@ -244073,8 +244073,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.2">
-          <h3>50.3. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-72.2)</code>
+        <div class="sect2" id="local-type.typedef-77.2">
+          <h3>50.3. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-77.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -244094,7 +244094,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.2)</code>
+                      <code>  (typedef-77.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -244328,8 +244328,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-6.2">
-          <h3>50.4. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-6.2)</code>
+        <div class="sect2" id="local-type.typedef-33.2">
+          <h3>50.4. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-33.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -244349,7 +244349,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-6.2)</code>
+                      <code>  (typedef-33.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -244657,8 +244657,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.4">
-          <h3>50.5. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-72.4)</code>
+        <div class="sect2" id="local-type.typedef-77.4">
+          <h3>50.5. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-77.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -244678,7 +244678,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.4)</code>
+                      <code>  (typedef-77.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -244922,7 +244922,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-1.1" title="local-type: typedef-1.1">local-type: typedef-1.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
                       </em>
                     </p>
                   </td>
@@ -244983,8 +244983,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-1.1">
-          <h3>50.6. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-1.1)</code>
+        <div class="sect2" id="local-type.typedef-34.1">
+          <h3>50.6. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -245004,7 +245004,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-1.1)</code>
+                      <code>  (typedef-34.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">

--- a/xsd/siri_model/siri_estimatedVehicleJourney.xsd
+++ b/xsd/siri_model/siri_estimatedVehicleJourney.xsd
@@ -363,6 +363,11 @@ the original journey and the nature of the difference.</xsd:documentation>
 					<xsd:documentation>Relations of the journey with other journeys, e.g., in case a joining/splitting takes place or the journey substitutes for another one etc.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="UpdatedServiceLinks" type="ServiceLinkViewsStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>List of SERVICE LINKs having updated shapes in that journey. This is only to provide updated the shapes of the journey (as gml:linestring), not to provide additional SERVICE LINK (provided through the sequence of CALLS)</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element ref="Extensions" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:complexType>

--- a/xsd/siri_model/siri_journey.xsd
+++ b/xsd/siri_model/siri_journey.xsd
@@ -132,6 +132,8 @@ Rail transport, Roads and road transport
 	<xsd:import namespace="http://www.ifopt.org.uk/ifopt" schemaLocation="../ifopt/ifopt_allStopPlace.xsd"/>
 	<!-- Global import of all ACSB namespace elements used in SIRI needed to work around JAXB/XERCES/xmllint limitations -->
 	<xsd:import namespace="http://www.ifopt.org.uk/acsb" schemaLocation="../acsb/acsb_all.xsd"/>
+	<!-- For GML (GIS features) -->
+	<xsd:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="../gml/gml_extract_all_objects.xsd"/>
 	<!-- ==== VEHICLEJOURNEY ================================================================== -->
 	<xsd:group name="JourneyInfoGroup">
 		<xsd:annotation>
@@ -1907,5 +1909,40 @@ TRAINs within a COMPOUND TRAIN may have different origins and destinations due t
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<!-- ======================================================================================================== -->
+	<!-- Service Links ======================================================================= -->
+		<xsd:complexType name="ServiceLinkViewsStructure">
+		<xsd:annotation>
+			<xsd:documentation>Provides information about updated SERVICE LINKs</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="ServiceLinkView" type="ServiceLinkViewStructure" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ServiceLinkViewStructure">
+		<xsd:annotation>
+			<xsd:documentation>Simplified description of an update of a SERVICE LINK, in order to provide an updated schematic shape (not ROUTE POINTs) in case of rerouting. Only updated ServiceLink are expected to be provided here, the scheduled one being provided by a NeTEx feed. The SERVICE JOURNEY itself is knonw from hte context</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="FromStopPointRef" type="StopPointRefStructure">
+				<xsd:annotation>
+					<xsd:documentation>Reference to the SCHEDULED STOP POINT at which the related SERVICE LINK begins.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="ToStopPointRef" type="StopPointRefStructure">
+				<xsd:annotation>
+					<xsd:documentation>Reference to the SCHEDULED STOP POINT at which the related SERVICE LINK ends.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Distance" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Length of LINK.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="gml:LineString" minOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>The shape (LineString) is mandatory in order to be consistent with the use case, which is to update the shape</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
 </xsd:schema>

--- a/xsd/siri_model/siri_situation.xsd
+++ b/xsd/siri_model/siri_situation.xsd
@@ -1289,6 +1289,11 @@ Note: this means that ReasonName is NOT a complete message, but only a (few) wor
 					<xsd:documentation>Description of fare exceptions allowed because of disruption.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="UpdatedServiceLinks" type="ServiceLinkViewsStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>List of SERVICE LINKs having updated shapes in that journey. This is only to provide updated the shapes of the journey (as gml:linestring), not to provide additional SERVICE LINK (provided through the sequence of CALLS)</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element ref="Extensions" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:complexType>


### PR DESCRIPTION
_**First proposal to include ServiceLinks**_
Provides a simplified description of an update of a SERVICE LINK, in order to provide an updated schematic shape (not ROUTE POINTs) in case of rerouting. Only updated ServiceLink are expected to be provided here, the scheduled one being provided by a NeTEx feed. The SERVICE JOURNEY itself is knonw from hte context.
Note that, The shape (LineString) is mandatory in order to be consistent with the use case, which is to update the shape.
In this initial proposal, the Service Links update can be inserted either in a EstimatedVehicleJourneyStructure (to be repeated for each journey) either in a consequence of a PTSituation (can be shared accross multiple journeys). As usual, the EstimatedVehicleJourneyStructure  can be linked with the PTSituation.
