### PR TITLE
Replace NaturalLanguagePlaceNameStructure as type of origin and destination elements

### DIFF
--- a/docs/generated/contab/acsb.html
+++ b/docs/generated/contab/acsb.html
@@ -248,7 +248,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-25.1" title="local-type: typedef-25.1">local-type: typedef-25.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-24.1" title="local-type: typedef-24.1">local-type: typedef-24.1</a>
                       </em>
                     </p>
                   </td>
@@ -272,7 +272,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-25.2" title="local-type: typedef-25.2">local-type: typedef-25.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-24.2" title="local-type: typedef-24.2">local-type: typedef-24.2</a>
                       </em>
                     </p>
                   </td>
@@ -297,7 +297,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-8.1" title="local-type: typedef-8.1">local-type: typedef-8.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.1" title="local-type: typedef-60.1">local-type: typedef-60.1</a>
                       </em>
                     </p>
                   </td>
@@ -544,7 +544,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-8.1" title="local-type: typedef-8.1">local-type: typedef-8.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.1" title="local-type: typedef-60.1">local-type: typedef-60.1</a>
                       </em>
                     </p>
                   </td>
@@ -589,8 +589,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-25.1">
-          <h3>1.6. The complex type <code>complexType[acsb:AccessibilityAssessmentStructure]/Limitations#complexType (typedef-25.1)</code>
+        <div class="sect2" id="local-type.typedef-24.1">
+          <h3>1.6. The complex type <code>complexType[acsb:AccessibilityAssessmentStructure]/Limitations#complexType (typedef-24.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -610,7 +610,7 @@
                       <br/>
                       <code>  /Limitations #complexType</code>
                       <br/>
-                      <code>  (typedef-25.1)</code>
+                      <code>  (typedef-24.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -652,8 +652,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-25.2">
-          <h3>1.7. The complex type <code>complexType[acsb:AccessibilityAssessmentStructure]/Suitabilities#complexType (typedef-25.2)</code>
+        <div class="sect2" id="local-type.typedef-24.2">
+          <h3>1.7. The complex type <code>complexType[acsb:AccessibilityAssessmentStructure]/Suitabilities#complexType (typedef-24.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -673,7 +673,7 @@
                       <br/>
                       <code>  /Suitabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-25.2)</code>
+                      <code>  (typedef-24.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -715,8 +715,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-8.1">
-          <h3>1.8. The complex type <code>element[ifopt:Extensions]#complexType (typedef-8.1)</code>
+        <div class="sect2" id="local-type.typedef-60.1">
+          <h3>1.8. The complex type <code>element[ifopt:Extensions]#complexType (typedef-60.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -736,7 +736,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-8.1)</code>
+                      <code>  (typedef-60.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -752,8 +752,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-8.1">
-          <h3>1.9. The complex type <code>element[ifopt:Extensions]#complexType (typedef-8.1)</code>
+        <div class="sect2" id="local-type.typedef-60.1">
+          <h3>1.9. The complex type <code>element[ifopt:Extensions]#complexType (typedef-60.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -773,7 +773,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-8.1)</code>
+                      <code>  (typedef-60.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">

--- a/docs/generated/contab/datex2.html
+++ b/docs/generated/contab/datex2.html
@@ -107112,7 +107112,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-23.1" title="local-type: typedef-23.1">local-type: typedef-23.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-17.1" title="local-type: typedef-17.1">local-type: typedef-17.1</a>
                       </em>
                     </p>
                   </td>
@@ -111020,7 +111020,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-23.2" title="local-type: typedef-23.2">local-type: typedef-23.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-17.2" title="local-type: typedef-17.2">local-type: typedef-17.2</a>
                       </em>
                     </p>
                   </td>
@@ -111865,7 +111865,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-23.3" title="local-type: typedef-23.3">local-type: typedef-23.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-17.3" title="local-type: typedef-17.3">local-type: typedef-17.3</a>
                       </em>
                     </p>
                   </td>
@@ -127573,7 +127573,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-23.4" title="local-type: typedef-23.4">local-type: typedef-23.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-17.4" title="local-type: typedef-17.4">local-type: typedef-17.4</a>
                       </em>
                     </p>
                   </td>
@@ -145442,8 +145442,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-23.1">
-          <h3>2.327. The complex type <code>complexType[Itinerary]/locationContainedInItinerary#complexType (typedef-23.1)</code>
+        <div class="sect2" id="local-type.typedef-17.1">
+          <h3>2.327. The complex type <code>complexType[Itinerary]/locationContainedInItinerary#complexType (typedef-17.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -145463,7 +145463,7 @@
                       <br/>
                       <code>  /locationContainedInItinerary #complexType</code>
                       <br/>
-                      <code>  (typedef-23.1)</code>
+                      <code>  (typedef-17.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -145588,8 +145588,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-23.2">
-          <h3>2.328. The complex type <code>complexType[MeasurementSiteRecord]/measurementSpecificCharacteristics#complexType (typedef-23.2)</code>
+        <div class="sect2" id="local-type.typedef-17.2">
+          <h3>2.328. The complex type <code>complexType[MeasurementSiteRecord]/measurementSpecificCharacteristics#complexType (typedef-17.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -145609,7 +145609,7 @@
                       <br/>
                       <code>  /measurementSpecificCharacteristics #complexType</code>
                       <br/>
-                      <code>  (typedef-23.2)</code>
+                      <code>  (typedef-17.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -145839,8 +145839,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-23.3">
-          <h3>2.329. The complex type <code>complexType[MultilingualString]/values#complexType (typedef-23.3)</code>
+        <div class="sect2" id="local-type.typedef-17.3">
+          <h3>2.329. The complex type <code>complexType[MultilingualString]/values#complexType (typedef-17.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -145860,7 +145860,7 @@
                       <br/>
                       <code>  /values #complexType</code>
                       <br/>
-                      <code>  (typedef-23.3)</code>
+                      <code>  (typedef-17.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -145902,8 +145902,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-23.4">
-          <h3>2.330. The complex type <code>complexType[SiteMeasurements]/measuredValue#complexType (typedef-23.4)</code>
+        <div class="sect2" id="local-type.typedef-17.4">
+          <h3>2.330. The complex type <code>complexType[SiteMeasurements]/measuredValue#complexType (typedef-17.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -145923,7 +145923,7 @@
                       <br/>
                       <code>  /measuredValue #complexType</code>
                       <br/>
-                      <code>  (typedef-23.4)</code>
+                      <code>  (typedef-17.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">

--- a/docs/generated/contab/ifopt.html
+++ b/docs/generated/contab/ifopt.html
@@ -7206,7 +7206,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-9.1" title="local-type: typedef-9.1">local-type: typedef-9.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-55.1" title="local-type: typedef-55.1">local-type: typedef-55.1</a>
                       </em>
                     </p>
                   </td>
@@ -8212,7 +8212,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-9.1" title="local-type: typedef-9.1">local-type: typedef-9.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-55.1" title="local-type: typedef-55.1">local-type: typedef-55.1</a>
                       </em>
                     </p>
                   </td>
@@ -8237,7 +8237,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-8.1" title="local-type: typedef-8.1">local-type: typedef-8.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.1" title="local-type: typedef-60.1">local-type: typedef-60.1</a>
                       </em>
                     </p>
                   </td>
@@ -8562,7 +8562,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-8.1" title="local-type: typedef-8.1">local-type: typedef-8.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-60.1" title="local-type: typedef-60.1">local-type: typedef-60.1</a>
                       </em>
                     </p>
                   </td>
@@ -8574,8 +8574,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-9.1">
-          <h3>4.15. The complex type <code>group[ifopt:LocalServiceGroup]/FeatureRefs#complexType (typedef-9.1)</code>
+        <div class="sect2" id="local-type.typedef-55.1">
+          <h3>4.15. The complex type <code>group[ifopt:LocalServiceGroup]/FeatureRefs#complexType (typedef-55.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -8595,7 +8595,7 @@
                       <br/>
                       <code>  /FeatureRefs #complexType</code>
                       <br/>
-                      <code>  (typedef-9.1)</code>
+                      <code>  (typedef-55.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -8633,8 +8633,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-9.1">
-          <h3>4.16. The complex type <code>group[ifopt:LocalServiceGroup]/FeatureRefs#complexType (typedef-9.1)</code>
+        <div class="sect2" id="local-type.typedef-55.1">
+          <h3>4.16. The complex type <code>group[ifopt:LocalServiceGroup]/FeatureRefs#complexType (typedef-55.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -8654,7 +8654,7 @@
                       <br/>
                       <code>  /FeatureRefs #complexType</code>
                       <br/>
-                      <code>  (typedef-9.1)</code>
+                      <code>  (typedef-55.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -8692,8 +8692,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-8.1">
-          <h3>4.17. The complex type <code>element[ifopt:Extensions]#complexType (typedef-8.1)</code>
+        <div class="sect2" id="local-type.typedef-60.1">
+          <h3>4.17. The complex type <code>element[ifopt:Extensions]#complexType (typedef-60.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -8713,7 +8713,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-8.1)</code>
+                      <code>  (typedef-60.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -8729,8 +8729,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-8.1">
-          <h3>4.18. The complex type <code>element[ifopt:Extensions]#complexType (typedef-8.1)</code>
+        <div class="sect2" id="local-type.typedef-60.1">
+          <h3>4.18. The complex type <code>element[ifopt:Extensions]#complexType (typedef-60.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -8750,7 +8750,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-8.1)</code>
+                      <code>  (typedef-60.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -9391,7 +9391,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-14.1" title="local-type: typedef-14.1">local-type: typedef-14.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.1" title="local-type: typedef-57.1">local-type: typedef-57.1</a>
                       </em>
                     </p>
                   </td>
@@ -9568,7 +9568,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-14.1" title="local-type: typedef-14.1">local-type: typedef-14.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.1" title="local-type: typedef-57.1">local-type: typedef-57.1</a>
                       </em>
                     </p>
                   </td>
@@ -9597,7 +9597,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-14.2" title="local-type: typedef-14.2">local-type: typedef-14.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.2" title="local-type: typedef-57.2">local-type: typedef-57.2</a>
                       </em>
                     </p>
                   </td>
@@ -9659,7 +9659,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-14.1" title="local-type: typedef-14.1">local-type: typedef-14.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.1" title="local-type: typedef-57.1">local-type: typedef-57.1</a>
                       </em>
                     </p>
                   </td>
@@ -9908,7 +9908,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-14.1" title="local-type: typedef-14.1">local-type: typedef-14.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.1" title="local-type: typedef-57.1">local-type: typedef-57.1</a>
                       </em>
                     </p>
                   </td>
@@ -9941,7 +9941,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-14.3" title="local-type: typedef-14.3">local-type: typedef-14.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-57.3" title="local-type: typedef-57.3">local-type: typedef-57.3</a>
                       </em>
                     </p>
                   </td>
@@ -9953,8 +9953,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-14.1">
-          <h3>5.17. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-14.1)</code>
+        <div class="sect2" id="local-type.typedef-57.1">
+          <h3>5.17. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-57.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -9974,7 +9974,7 @@
                       <br/>
                       <code>  /Features #complexType</code>
                       <br/>
-                      <code>  (typedef-14.1)</code>
+                      <code>  (typedef-57.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -10016,8 +10016,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-14.1">
-          <h3>5.18. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-14.1)</code>
+        <div class="sect2" id="local-type.typedef-57.1">
+          <h3>5.18. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-57.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -10037,7 +10037,7 @@
                       <br/>
                       <code>  /Features #complexType</code>
                       <br/>
-                      <code>  (typedef-14.1)</code>
+                      <code>  (typedef-57.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -10079,8 +10079,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-14.2">
-          <h3>5.19. The complex type <code>complexType[ifopt:LinkProjectionStructure]/Line#complexType (typedef-14.2)</code>
+        <div class="sect2" id="local-type.typedef-57.2">
+          <h3>5.19. The complex type <code>complexType[ifopt:LinkProjectionStructure]/Line#complexType (typedef-57.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -10100,7 +10100,7 @@
                       <br/>
                       <code>  /Line #complexType</code>
                       <br/>
-                      <code>  (typedef-14.2)</code>
+                      <code>  (typedef-57.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -10143,8 +10143,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-14.1">
-          <h3>5.20. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-14.1)</code>
+        <div class="sect2" id="local-type.typedef-57.1">
+          <h3>5.20. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-57.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -10164,7 +10164,7 @@
                       <br/>
                       <code>  /Features #complexType</code>
                       <br/>
-                      <code>  (typedef-14.1)</code>
+                      <code>  (typedef-57.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -10206,8 +10206,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-14.1">
-          <h3>5.21. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-14.1)</code>
+        <div class="sect2" id="local-type.typedef-57.1">
+          <h3>5.21. The complex type <code>complexType[ifopt:AbstractProjection]/Features#complexType (typedef-57.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -10227,7 +10227,7 @@
                       <br/>
                       <code>  /Features #complexType</code>
                       <br/>
-                      <code>  (typedef-14.1)</code>
+                      <code>  (typedef-57.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -10269,8 +10269,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-14.3">
-          <h3>5.22. The complex type <code>complexType[ifopt:ZoneProjectionStructure]/Boundary#complexType (typedef-14.3)</code>
+        <div class="sect2" id="local-type.typedef-57.3">
+          <h3>5.22. The complex type <code>complexType[ifopt:ZoneProjectionStructure]/Boundary#complexType (typedef-57.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -10290,7 +10290,7 @@
                       <br/>
                       <code>  /Boundary #complexType</code>
                       <br/>
-                      <code>  (typedef-14.3)</code>
+                      <code>  (typedef-57.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -13149,7 +13149,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-17.1" title="local-type: typedef-17.1">local-type: typedef-17.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-56.1" title="local-type: typedef-56.1">local-type: typedef-56.1</a>
                       </em>
                     </p>
                   </td>
@@ -13161,8 +13161,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-17.1">
-          <h3>10.5. The complex type <code>complexType[ifopt:ValidityConditionStructure]/Timebands#complexType (typedef-17.1)</code>
+        <div class="sect2" id="local-type.typedef-56.1">
+          <h3>10.5. The complex type <code>complexType[ifopt:ValidityConditionStructure]/Timebands#complexType (typedef-56.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -13182,7 +13182,7 @@
                       <br/>
                       <code>  /Timebands #complexType</code>
                       <br/>
-                      <code>  (typedef-17.1)</code>
+                      <code>  (typedef-56.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -13416,8 +13416,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-8.1">
-          <h3>11.7. The complex type <code>element[ifopt:Extensions]#complexType (typedef-8.1)</code>
+        <div class="sect2" id="local-type.typedef-60.1">
+          <h3>11.7. The complex type <code>element[ifopt:Extensions]#complexType (typedef-60.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -13437,7 +13437,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-8.1)</code>
+                      <code>  (typedef-60.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">

--- a/docs/generated/contab/siri.html
+++ b/docs/generated/contab/siri.html
@@ -5527,7 +5527,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.1" title="local-type: typedef-18.1">local-type: typedef-18.1</a>
                       </em>
                     </p>
                   </td>
@@ -5936,7 +5936,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.2" title="local-type: typedef-75.2">local-type: typedef-75.2</a>
                       </em>
                     </p>
                   </td>
@@ -5967,7 +5967,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-33.2" title="local-type: typedef-33.2">local-type: typedef-33.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-19.2" title="local-type: typedef-19.2">local-type: typedef-19.2</a>
                       </em>
                     </p>
                   </td>
@@ -6353,7 +6353,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.4" title="local-type: typedef-77.4">local-type: typedef-77.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.4" title="local-type: typedef-75.4">local-type: typedef-75.4</a>
                       </em>
                     </p>
                   </td>
@@ -6949,7 +6949,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.4" title="local-type: typedef-77.4">local-type: typedef-77.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.4" title="local-type: typedef-75.4">local-type: typedef-75.4</a>
                       </em>
                     </p>
                   </td>
@@ -7055,7 +7055,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.2" title="local-type: typedef-75.2">local-type: typedef-75.2</a>
                       </em>
                     </p>
                   </td>
@@ -7086,7 +7086,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.3" title="local-type: typedef-77.3">local-type: typedef-77.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.3" title="local-type: typedef-75.3">local-type: typedef-75.3</a>
                       </em>
                     </p>
                   </td>
@@ -7335,7 +7335,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.1" title="local-type: typedef-72.1">local-type: typedef-72.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.1" title="local-type: typedef-77.1">local-type: typedef-77.1</a>
                       </em>
                     </p>
                   </td>
@@ -7397,7 +7397,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
                       </em>
                     </p>
                   </td>
@@ -7728,7 +7728,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.4" title="local-type: typedef-77.4">local-type: typedef-77.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.4" title="local-type: typedef-75.4">local-type: typedef-75.4</a>
                       </em>
                     </p>
                   </td>
@@ -8168,7 +8168,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.1" title="local-type: typedef-18.1">local-type: typedef-18.1</a>
                       </em>
                     </p>
                   </td>
@@ -8662,7 +8662,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.2" title="local-type: typedef-75.2">local-type: typedef-75.2</a>
                       </em>
                     </p>
                   </td>
@@ -8693,7 +8693,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.3" title="local-type: typedef-77.3">local-type: typedef-77.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.3" title="local-type: typedef-75.3">local-type: typedef-75.3</a>
                       </em>
                     </p>
                   </td>
@@ -8965,7 +8965,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.1" title="local-type: typedef-72.1">local-type: typedef-72.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.1" title="local-type: typedef-77.1">local-type: typedef-77.1</a>
                       </em>
                     </p>
                   </td>
@@ -9027,7 +9027,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
                       </em>
                     </p>
                   </td>
@@ -9564,7 +9564,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.3" title="local-type: typedef-79.3">local-type: typedef-79.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.3" title="local-type: typedef-76.3">local-type: typedef-76.3</a>
                       </em>
                     </p>
                   </td>
@@ -10878,7 +10878,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.2" title="local-type: typedef-79.2">local-type: typedef-79.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.2" title="local-type: typedef-76.2">local-type: typedef-76.2</a>
                       </em>
                     </p>
                   </td>
@@ -11425,7 +11425,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.3" title="local-type: typedef-79.3">local-type: typedef-79.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.3" title="local-type: typedef-76.3">local-type: typedef-76.3</a>
                       </em>
                     </p>
                   </td>
@@ -12184,7 +12184,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.1" title="local-type: typedef-18.1">local-type: typedef-18.1</a>
                       </em>
                     </p>
                   </td>
@@ -12886,7 +12886,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.1" title="local-type: typedef-18.1">local-type: typedef-18.1</a>
                       </em>
                     </p>
                   </td>
@@ -14402,7 +14402,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.2" title="local-type: typedef-79.2">local-type: typedef-79.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.2" title="local-type: typedef-76.2">local-type: typedef-76.2</a>
                       </em>
                     </p>
                   </td>
@@ -15021,7 +15021,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.2" title="local-type: typedef-79.2">local-type: typedef-79.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.2" title="local-type: typedef-76.2">local-type: typedef-76.2</a>
                       </em>
                     </p>
                   </td>
@@ -15312,8 +15312,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.4">
-          <h3>1.28. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-77.4)</code>
+        <div class="sect2" id="local-type.typedef-75.4">
+          <h3>1.28. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-75.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -15333,7 +15333,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.4)</code>
+                      <code>  (typedef-75.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -15577,7 +15577,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.1" title="local-type: typedef-18.1">local-type: typedef-18.1</a>
                       </em>
                     </p>
                   </td>
@@ -15638,8 +15638,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-34.1">
-          <h3>1.29. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
+        <div class="sect2" id="local-type.typedef-18.1">
+          <h3>1.29. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-18.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -15659,7 +15659,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-34.1)</code>
+                      <code>  (typedef-18.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -15770,8 +15770,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.2">
-          <h3>1.30. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-77.2)</code>
+        <div class="sect2" id="local-type.typedef-75.2">
+          <h3>1.30. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-75.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -15791,7 +15791,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.2)</code>
+                      <code>  (typedef-75.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -16025,8 +16025,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.1">
-          <h3>1.31. The complex type <code>element[siri:Siri]#complexType (typedef-77.1)</code>
+        <div class="sect2" id="local-type.typedef-75.1">
+          <h3>1.31. The complex type <code>element[siri:Siri]#complexType (typedef-75.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -16046,7 +16046,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.1)</code>
+                      <code>  (typedef-75.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -16126,7 +16126,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.2" title="local-type: typedef-75.2">local-type: typedef-75.2</a>
                       </em>
                     </p>
                   </td>
@@ -16157,7 +16157,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-33.2" title="local-type: typedef-33.2">local-type: typedef-33.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-19.2" title="local-type: typedef-19.2">local-type: typedef-19.2</a>
                       </em>
                     </p>
                   </td>
@@ -16543,7 +16543,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.4" title="local-type: typedef-77.4">local-type: typedef-77.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.4" title="local-type: typedef-75.4">local-type: typedef-75.4</a>
                       </em>
                     </p>
                   </td>
@@ -16725,8 +16725,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.2">
-          <h3>1.32. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-77.2)</code>
+        <div class="sect2" id="local-type.typedef-75.2">
+          <h3>1.32. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-75.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -16746,7 +16746,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.2)</code>
+                      <code>  (typedef-75.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -16980,8 +16980,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-33.2">
-          <h3>1.33. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-33.2)</code>
+        <div class="sect2" id="local-type.typedef-19.2">
+          <h3>1.33. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-19.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -17001,7 +17001,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-33.2)</code>
+                      <code>  (typedef-19.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -17309,8 +17309,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.4">
-          <h3>1.34. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-77.4)</code>
+        <div class="sect2" id="local-type.typedef-75.4">
+          <h3>1.34. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-75.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -17330,7 +17330,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.4)</code>
+                      <code>  (typedef-75.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -17574,7 +17574,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.1" title="local-type: typedef-18.1">local-type: typedef-18.1</a>
                       </em>
                     </p>
                   </td>
@@ -17635,8 +17635,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-34.1">
-          <h3>1.35. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
+        <div class="sect2" id="local-type.typedef-18.1">
+          <h3>1.35. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-18.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -17656,7 +17656,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-34.1)</code>
+                      <code>  (typedef-18.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -17767,8 +17767,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.3">
-          <h3>1.36. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-77.3)</code>
+        <div class="sect2" id="local-type.typedef-75.3">
+          <h3>1.36. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-75.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -17788,7 +17788,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.3)</code>
+                      <code>  (typedef-75.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -18096,8 +18096,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.4">
-          <h3>1.37. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-77.4)</code>
+        <div class="sect2" id="local-type.typedef-75.4">
+          <h3>1.37. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-75.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -18117,7 +18117,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.4)</code>
+                      <code>  (typedef-75.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -18361,7 +18361,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.1" title="local-type: typedef-18.1">local-type: typedef-18.1</a>
                       </em>
                     </p>
                   </td>
@@ -18422,8 +18422,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-34.1">
-          <h3>1.38. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
+        <div class="sect2" id="local-type.typedef-18.1">
+          <h3>1.38. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-18.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -18443,7 +18443,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-34.1)</code>
+                      <code>  (typedef-18.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -18554,8 +18554,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.2">
-          <h3>1.39. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-77.2)</code>
+        <div class="sect2" id="local-type.typedef-75.2">
+          <h3>1.39. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-75.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -18575,7 +18575,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.2)</code>
+                      <code>  (typedef-75.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -18809,8 +18809,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.3">
-          <h3>1.40. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-77.3)</code>
+        <div class="sect2" id="local-type.typedef-75.3">
+          <h3>1.40. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-75.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -18830,7 +18830,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.3)</code>
+                      <code>  (typedef-75.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -19138,8 +19138,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.1">
-          <h3>1.41. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-72.1)</code>
+        <div class="sect2" id="local-type.typedef-77.1">
+          <h3>1.41. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-77.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -19159,7 +19159,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.1)</code>
+                      <code>  (typedef-77.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -19549,8 +19549,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.2">
-          <h3>1.42. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-72.2)</code>
+        <div class="sect2" id="local-type.typedef-77.2">
+          <h3>1.42. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-77.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -19570,7 +19570,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.2)</code>
+                      <code>  (typedef-77.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -19788,8 +19788,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.4">
-          <h3>1.43. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-77.4)</code>
+        <div class="sect2" id="local-type.typedef-75.4">
+          <h3>1.43. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-75.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -19809,7 +19809,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.4)</code>
+                      <code>  (typedef-75.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -20053,7 +20053,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.1" title="local-type: typedef-18.1">local-type: typedef-18.1</a>
                       </em>
                     </p>
                   </td>
@@ -20114,8 +20114,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-34.1">
-          <h3>1.44. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
+        <div class="sect2" id="local-type.typedef-18.1">
+          <h3>1.44. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-18.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -20135,7 +20135,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-34.1)</code>
+                      <code>  (typedef-18.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -20246,8 +20246,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-34.1">
-          <h3>1.45. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
+        <div class="sect2" id="local-type.typedef-18.1">
+          <h3>1.45. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-18.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -20267,7 +20267,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-34.1)</code>
+                      <code>  (typedef-18.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -20378,8 +20378,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.2">
-          <h3>1.46. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-77.2)</code>
+        <div class="sect2" id="local-type.typedef-75.2">
+          <h3>1.46. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-75.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -20399,7 +20399,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.2)</code>
+                      <code>  (typedef-75.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -20633,8 +20633,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.3">
-          <h3>1.47. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-77.3)</code>
+        <div class="sect2" id="local-type.typedef-75.3">
+          <h3>1.47. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-75.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -20654,7 +20654,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.3)</code>
+                      <code>  (typedef-75.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -20962,8 +20962,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.1">
-          <h3>1.48. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-72.1)</code>
+        <div class="sect2" id="local-type.typedef-77.1">
+          <h3>1.48. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-77.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -20983,7 +20983,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.1)</code>
+                      <code>  (typedef-77.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -21373,8 +21373,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.2">
-          <h3>1.49. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-72.2)</code>
+        <div class="sect2" id="local-type.typedef-77.2">
+          <h3>1.49. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-77.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -21394,7 +21394,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.2)</code>
+                      <code>  (typedef-77.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -21612,8 +21612,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.3">
-          <h3>1.50. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-79.3)</code>
+        <div class="sect2" id="local-type.typedef-76.3">
+          <h3>1.50. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-76.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -21633,7 +21633,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-79.3)</code>
+                      <code>  (typedef-76.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -21783,8 +21783,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.2">
-          <h3>1.51. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-79.2)</code>
+        <div class="sect2" id="local-type.typedef-76.2">
+          <h3>1.51. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-76.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -21804,7 +21804,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-79.2)</code>
+                      <code>  (typedef-76.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -22001,8 +22001,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.3">
-          <h3>1.52. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-79.3)</code>
+        <div class="sect2" id="local-type.typedef-76.3">
+          <h3>1.52. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-76.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -22022,7 +22022,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-79.3)</code>
+                      <code>  (typedef-76.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -22172,8 +22172,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-34.1">
-          <h3>1.53. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
+        <div class="sect2" id="local-type.typedef-18.1">
+          <h3>1.53. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-18.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -22193,7 +22193,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-34.1)</code>
+                      <code>  (typedef-18.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -22304,8 +22304,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-34.1">
-          <h3>1.54. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
+        <div class="sect2" id="local-type.typedef-18.1">
+          <h3>1.54. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-18.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -22325,7 +22325,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-34.1)</code>
+                      <code>  (typedef-18.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -22436,8 +22436,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.2">
-          <h3>1.55. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-79.2)</code>
+        <div class="sect2" id="local-type.typedef-76.2">
+          <h3>1.55. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-76.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -22457,7 +22457,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-79.2)</code>
+                      <code>  (typedef-76.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -22654,8 +22654,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.2">
-          <h3>1.56. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-79.2)</code>
+        <div class="sect2" id="local-type.typedef-76.2">
+          <h3>1.56. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-76.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -22675,7 +22675,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-79.2)</code>
+                      <code>  (typedef-76.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -23204,7 +23204,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.1" title="local-type: typedef-18.1">local-type: typedef-18.1</a>
                       </em>
                     </p>
                   </td>
@@ -23964,7 +23964,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.4" title="local-type: typedef-77.4">local-type: typedef-77.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.4" title="local-type: typedef-75.4">local-type: typedef-75.4</a>
                       </em>
                     </p>
                   </td>
@@ -24272,7 +24272,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.2" title="local-type: typedef-75.2">local-type: typedef-75.2</a>
                       </em>
                     </p>
                   </td>
@@ -24303,7 +24303,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.3" title="local-type: typedef-77.3">local-type: typedef-77.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.3" title="local-type: typedef-75.3">local-type: typedef-75.3</a>
                       </em>
                     </p>
                   </td>
@@ -24720,7 +24720,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.4" title="local-type: typedef-77.4">local-type: typedef-77.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.4" title="local-type: typedef-75.4">local-type: typedef-75.4</a>
                       </em>
                     </p>
                   </td>
@@ -24935,7 +24935,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.1" title="local-type: typedef-18.1">local-type: typedef-18.1</a>
                       </em>
                     </p>
                   </td>
@@ -25054,7 +25054,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.2" title="local-type: typedef-75.2">local-type: typedef-75.2</a>
                       </em>
                     </p>
                   </td>
@@ -25085,7 +25085,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.3" title="local-type: typedef-77.3">local-type: typedef-77.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.3" title="local-type: typedef-75.3">local-type: typedef-75.3</a>
                       </em>
                     </p>
                   </td>
@@ -25845,7 +25845,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.1" title="local-type: typedef-18.1">local-type: typedef-18.1</a>
                       </em>
                     </p>
                   </td>
@@ -26547,7 +26547,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.1" title="local-type: typedef-18.1">local-type: typedef-18.1</a>
                       </em>
                     </p>
                   </td>
@@ -27329,7 +27329,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.2" title="local-type: typedef-75.2">local-type: typedef-75.2</a>
                       </em>
                     </p>
                   </td>
@@ -27360,7 +27360,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.3" title="local-type: typedef-77.3">local-type: typedef-77.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.3" title="local-type: typedef-75.3">local-type: typedef-75.3</a>
                       </em>
                     </p>
                   </td>
@@ -27609,7 +27609,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.1" title="local-type: typedef-72.1">local-type: typedef-72.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.1" title="local-type: typedef-77.1">local-type: typedef-77.1</a>
                       </em>
                     </p>
                   </td>
@@ -27671,7 +27671,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
                       </em>
                     </p>
                   </td>
@@ -27971,7 +27971,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.4" title="local-type: typedef-77.4">local-type: typedef-77.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.4" title="local-type: typedef-75.4">local-type: typedef-75.4</a>
                       </em>
                     </p>
                   </td>
@@ -28708,8 +28708,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-33.3">
-          <h3>2.21. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-33.3)</code>
+        <div class="sect2" id="local-type.typedef-19.3">
+          <h3>2.21. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-19.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -28729,7 +28729,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-33.3)</code>
+                      <code>  (typedef-19.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -28973,7 +28973,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.1" title="local-type: typedef-18.1">local-type: typedef-18.1</a>
                       </em>
                     </p>
                   </td>
@@ -29034,8 +29034,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-34.1">
-          <h3>2.22. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
+        <div class="sect2" id="local-type.typedef-18.1">
+          <h3>2.22. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-18.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -29055,7 +29055,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-34.1)</code>
+                      <code>  (typedef-18.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -29166,8 +29166,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-33.1">
-          <h3>2.23. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-33.1)</code>
+        <div class="sect2" id="local-type.typedef-19.1">
+          <h3>2.23. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-19.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -29187,7 +29187,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-33.1)</code>
+                      <code>  (typedef-19.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -29455,8 +29455,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-33.2">
-          <h3>2.24. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-33.2)</code>
+        <div class="sect2" id="local-type.typedef-19.2">
+          <h3>2.24. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-19.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -29476,7 +29476,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-33.2)</code>
+                      <code>  (typedef-19.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -29784,8 +29784,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.4">
-          <h3>2.25. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-77.4)</code>
+        <div class="sect2" id="local-type.typedef-75.4">
+          <h3>2.25. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-75.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -29805,7 +29805,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.4)</code>
+                      <code>  (typedef-75.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -30049,7 +30049,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.1" title="local-type: typedef-18.1">local-type: typedef-18.1</a>
                       </em>
                     </p>
                   </td>
@@ -30110,8 +30110,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-34.1">
-          <h3>2.26. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
+        <div class="sect2" id="local-type.typedef-18.1">
+          <h3>2.26. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-18.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -30131,7 +30131,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-34.1)</code>
+                      <code>  (typedef-18.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -30242,8 +30242,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.2">
-          <h3>2.27. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-77.2)</code>
+        <div class="sect2" id="local-type.typedef-75.2">
+          <h3>2.27. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-75.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -30263,7 +30263,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.2)</code>
+                      <code>  (typedef-75.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -30497,8 +30497,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.3">
-          <h3>2.28. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-77.3)</code>
+        <div class="sect2" id="local-type.typedef-75.3">
+          <h3>2.28. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-75.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -30518,7 +30518,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.3)</code>
+                      <code>  (typedef-75.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -30826,8 +30826,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.4">
-          <h3>2.29. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-77.4)</code>
+        <div class="sect2" id="local-type.typedef-75.4">
+          <h3>2.29. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-75.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -30847,7 +30847,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.4)</code>
+                      <code>  (typedef-75.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -31091,7 +31091,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.1" title="local-type: typedef-18.1">local-type: typedef-18.1</a>
                       </em>
                     </p>
                   </td>
@@ -31152,8 +31152,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-34.1">
-          <h3>2.30. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
+        <div class="sect2" id="local-type.typedef-18.1">
+          <h3>2.30. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-18.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -31173,7 +31173,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-34.1)</code>
+                      <code>  (typedef-18.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -31284,8 +31284,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-34.1">
-          <h3>2.31. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
+        <div class="sect2" id="local-type.typedef-18.1">
+          <h3>2.31. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-18.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -31305,7 +31305,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-34.1)</code>
+                      <code>  (typedef-18.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -31416,8 +31416,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.2">
-          <h3>2.32. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-77.2)</code>
+        <div class="sect2" id="local-type.typedef-75.2">
+          <h3>2.32. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-75.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -31437,7 +31437,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.2)</code>
+                      <code>  (typedef-75.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -31671,8 +31671,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.3">
-          <h3>2.33. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-77.3)</code>
+        <div class="sect2" id="local-type.typedef-75.3">
+          <h3>2.33. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-75.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -31692,7 +31692,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.3)</code>
+                      <code>  (typedef-75.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -32000,8 +32000,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-34.1">
-          <h3>2.34. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
+        <div class="sect2" id="local-type.typedef-18.1">
+          <h3>2.34. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-18.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -32021,7 +32021,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-34.1)</code>
+                      <code>  (typedef-18.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -32132,8 +32132,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-34.1">
-          <h3>2.35. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
+        <div class="sect2" id="local-type.typedef-18.1">
+          <h3>2.35. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-18.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -32153,7 +32153,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-34.1)</code>
+                      <code>  (typedef-18.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -32264,8 +32264,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.2">
-          <h3>2.36. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-77.2)</code>
+        <div class="sect2" id="local-type.typedef-75.2">
+          <h3>2.36. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-75.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -32285,7 +32285,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.2)</code>
+                      <code>  (typedef-75.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -32519,8 +32519,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.3">
-          <h3>2.37. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-77.3)</code>
+        <div class="sect2" id="local-type.typedef-75.3">
+          <h3>2.37. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-75.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -32540,7 +32540,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.3)</code>
+                      <code>  (typedef-75.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -32848,8 +32848,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.1">
-          <h3>2.38. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-72.1)</code>
+        <div class="sect2" id="local-type.typedef-77.1">
+          <h3>2.38. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-77.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -32869,7 +32869,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.1)</code>
+                      <code>  (typedef-77.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -33259,8 +33259,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.2">
-          <h3>2.39. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-72.2)</code>
+        <div class="sect2" id="local-type.typedef-77.2">
+          <h3>2.39. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-77.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -33280,7 +33280,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.2)</code>
+                      <code>  (typedef-77.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -33498,8 +33498,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.4">
-          <h3>2.40. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-77.4)</code>
+        <div class="sect2" id="local-type.typedef-75.4">
+          <h3>2.40. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-75.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -33519,7 +33519,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.4)</code>
+                      <code>  (typedef-75.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -33763,7 +33763,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.1" title="local-type: typedef-18.1">local-type: typedef-18.1</a>
                       </em>
                     </p>
                   </td>
@@ -33824,8 +33824,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-34.1">
-          <h3>2.41. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
+        <div class="sect2" id="local-type.typedef-18.1">
+          <h3>2.41. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-18.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -33845,7 +33845,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-34.1)</code>
+                      <code>  (typedef-18.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -34534,7 +34534,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-29.4" title="local-type: typedef-29.4">local-type: typedef-29.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-20.4" title="local-type: typedef-20.4">local-type: typedef-20.4</a>
                       </em>
                     </p>
                   </td>
@@ -34800,7 +34800,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-29.3" title="local-type: typedef-29.3">local-type: typedef-29.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-20.3" title="local-type: typedef-20.3">local-type: typedef-20.3</a>
                       </em>
                     </p>
                   </td>
@@ -37040,7 +37040,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-29.4" title="local-type: typedef-29.4">local-type: typedef-29.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-20.4" title="local-type: typedef-20.4">local-type: typedef-20.4</a>
                       </em>
                     </p>
                   </td>
@@ -37378,7 +37378,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-29.4" title="local-type: typedef-29.4">local-type: typedef-29.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-20.4" title="local-type: typedef-20.4">local-type: typedef-20.4</a>
                       </em>
                     </p>
                   </td>
@@ -38293,7 +38293,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-29.2" title="local-type: typedef-29.2">local-type: typedef-29.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-20.2" title="local-type: typedef-20.2">local-type: typedef-20.2</a>
                       </em>
                     </p>
                   </td>
@@ -38500,7 +38500,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-29.3" title="local-type: typedef-29.3">local-type: typedef-29.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-20.3" title="local-type: typedef-20.3">local-type: typedef-20.3</a>
                       </em>
                     </p>
                   </td>
@@ -39138,7 +39138,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-29.4" title="local-type: typedef-29.4">local-type: typedef-29.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-20.4" title="local-type: typedef-20.4">local-type: typedef-20.4</a>
                       </em>
                     </p>
                   </td>
@@ -41615,7 +41615,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-29.1" title="local-type: typedef-29.1">local-type: typedef-29.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-20.1" title="local-type: typedef-20.1">local-type: typedef-20.1</a>
                       </em>
                     </p>
                   </td>
@@ -41627,8 +41627,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-29.4">
-          <h3>3.56. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-29.4)</code>
+        <div class="sect2" id="local-type.typedef-20.4">
+          <h3>3.56. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-20.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -41648,7 +41648,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-29.4)</code>
+                      <code>  (typedef-20.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -41759,8 +41759,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-29.3">
-          <h3>3.57. The complex type <code>group[siri:DataReceivedPayloadGroup]/ErrorCondition#complexType (typedef-29.3)</code>
+        <div class="sect2" id="local-type.typedef-20.3">
+          <h3>3.57. The complex type <code>group[siri:DataReceivedPayloadGroup]/ErrorCondition#complexType (typedef-20.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -41780,7 +41780,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-29.3)</code>
+                      <code>  (typedef-20.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -41891,8 +41891,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-29.4">
-          <h3>3.58. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-29.4)</code>
+        <div class="sect2" id="local-type.typedef-20.4">
+          <h3>3.58. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-20.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -41912,7 +41912,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-29.4)</code>
+                      <code>  (typedef-20.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -42023,8 +42023,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-29.4">
-          <h3>3.59. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-29.4)</code>
+        <div class="sect2" id="local-type.typedef-20.4">
+          <h3>3.59. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-20.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -42044,7 +42044,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-29.4)</code>
+                      <code>  (typedef-20.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -42155,8 +42155,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-29.2">
-          <h3>3.60. The complex type <code>complexType[siri:DataReadyResponseStructure]/ErrorCondition#complexType (typedef-29.2)</code>
+        <div class="sect2" id="local-type.typedef-20.2">
+          <h3>3.60. The complex type <code>complexType[siri:DataReadyResponseStructure]/ErrorCondition#complexType (typedef-20.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -42176,7 +42176,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-29.2)</code>
+                      <code>  (typedef-20.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -42287,8 +42287,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-29.3">
-          <h3>3.61. The complex type <code>group[siri:DataReceivedPayloadGroup]/ErrorCondition#complexType (typedef-29.3)</code>
+        <div class="sect2" id="local-type.typedef-20.3">
+          <h3>3.61. The complex type <code>group[siri:DataReceivedPayloadGroup]/ErrorCondition#complexType (typedef-20.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -42308,7 +42308,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-29.3)</code>
+                      <code>  (typedef-20.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -42419,8 +42419,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-29.4">
-          <h3>3.62. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-29.4)</code>
+        <div class="sect2" id="local-type.typedef-20.4">
+          <h3>3.62. The complex type <code>group[siri:CheckStatusPayloadGroup]/ErrorCondition#complexType (typedef-20.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -42440,7 +42440,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-29.4)</code>
+                      <code>  (typedef-20.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -42551,8 +42551,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-29.1">
-          <h3>3.63. The complex type <code>complexType[siri:TerminationResponseStatusStructure]/ErrorCondition#complexType (typedef-29.1)</code>
+        <div class="sect2" id="local-type.typedef-20.1">
+          <h3>3.63. The complex type <code>complexType[siri:TerminationResponseStatusStructure]/ErrorCondition#complexType (typedef-20.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -42572,7 +42572,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-29.1)</code>
+                      <code>  (typedef-20.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -50439,7 +50439,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.1" title="local-type: typedef-18.1">local-type: typedef-18.1</a>
                       </em>
                     </p>
                   </td>
@@ -53171,7 +53171,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-34.2" title="local-type: typedef-34.2">local-type: typedef-34.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.2" title="local-type: typedef-18.2">local-type: typedef-18.2</a>
                       </em>
                     </p>
                   </td>
@@ -53199,7 +53199,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-34.3" title="local-type: typedef-34.3">local-type: typedef-34.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.3" title="local-type: typedef-18.3">local-type: typedef-18.3</a>
                       </em>
                     </p>
                   </td>
@@ -55345,8 +55345,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-34.1">
-          <h3>6.64. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
+        <div class="sect2" id="local-type.typedef-18.1">
+          <h3>6.64. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-18.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -55366,7 +55366,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-34.1)</code>
+                      <code>  (typedef-18.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -55477,8 +55477,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-34.2">
-          <h3>6.65. The complex type <code>complexType[siri:CapabilityGeneralInteractionStructure]/Interaction#complexType (typedef-34.2)</code>
+        <div class="sect2" id="local-type.typedef-18.2">
+          <h3>6.65. The complex type <code>complexType[siri:CapabilityGeneralInteractionStructure]/Interaction#complexType (typedef-18.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -55498,7 +55498,7 @@
                       <br/>
                       <code>  /Interaction #complexType</code>
                       <br/>
-                      <code>  (typedef-34.2)</code>
+                      <code>  (typedef-18.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -55566,8 +55566,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-34.3">
-          <h3>6.66. The complex type <code>complexType[siri:CapabilityGeneralInteractionStructure]/Delivery#complexType (typedef-34.3)</code>
+        <div class="sect2" id="local-type.typedef-18.3">
+          <h3>6.66. The complex type <code>complexType[siri:CapabilityGeneralInteractionStructure]/Delivery#complexType (typedef-18.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -55587,7 +55587,7 @@
                       <br/>
                       <code>  /Delivery #complexType</code>
                       <br/>
-                      <code>  (typedef-34.3)</code>
+                      <code>  (typedef-18.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -57944,7 +57944,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.3" title="local-type: typedef-74.3">local-type: typedef-74.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-81.3" title="local-type: typedef-81.3">local-type: typedef-81.3</a>
                       </em>
                     </p>
                   </td>
@@ -59626,7 +59626,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.1" title="local-type: typedef-74.1">local-type: typedef-74.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-81.1" title="local-type: typedef-81.1">local-type: typedef-81.1</a>
                       </em>
                     </p>
                   </td>
@@ -59650,7 +59650,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-74.2" title="local-type: typedef-74.2">local-type: typedef-74.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-81.2" title="local-type: typedef-81.2">local-type: typedef-81.2</a>
                       </em>
                     </p>
                   </td>
@@ -61926,8 +61926,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.3">
-          <h3>7.37. The complex type <code>element[siri:ConnectionMonitoringPermissions]#complexType (typedef-74.3)</code>
+        <div class="sect2" id="local-type.typedef-81.3">
+          <h3>7.37. The complex type <code>element[siri:ConnectionMonitoringPermissions]#complexType (typedef-81.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -61947,7 +61947,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.3)</code>
+                      <code>  (typedef-81.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -61985,8 +61985,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.3">
-          <h3>7.38. The complex type <code>element[siri:ConnectionMonitoringPermissions]#complexType (typedef-74.3)</code>
+        <div class="sect2" id="local-type.typedef-81.3">
+          <h3>7.38. The complex type <code>element[siri:ConnectionMonitoringPermissions]#complexType (typedef-81.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -62006,7 +62006,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-74.3)</code>
+                      <code>  (typedef-81.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -62044,8 +62044,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.1">
-          <h3>7.39. The complex type <code>complexType[siri:ConnectionMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-74.1)</code>
+        <div class="sect2" id="local-type.typedef-81.1">
+          <h3>7.39. The complex type <code>complexType[siri:ConnectionMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-81.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -62065,7 +62065,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-74.1)</code>
+                      <code>  (typedef-81.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -62174,8 +62174,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-74.2">
-          <h3>7.40. The complex type <code>complexType[siri:ConnectionMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-74.2)</code>
+        <div class="sect2" id="local-type.typedef-81.2">
+          <h3>7.40. The complex type <code>complexType[siri:ConnectionMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-81.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -62195,7 +62195,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-74.2)</code>
+                      <code>  (typedef-81.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -63821,7 +63821,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-85.1" title="local-type: typedef-85.1">local-type: typedef-85.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-83.1" title="local-type: typedef-83.1">local-type: typedef-83.1</a>
                       </em>
                     </p>
                   </td>
@@ -64944,7 +64944,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-85.2" title="local-type: typedef-85.2">local-type: typedef-85.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-83.2" title="local-type: typedef-83.2">local-type: typedef-83.2</a>
                       </em>
                     </p>
                   </td>
@@ -64968,7 +64968,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-85.3" title="local-type: typedef-85.3">local-type: typedef-85.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-83.3" title="local-type: typedef-83.3">local-type: typedef-83.3</a>
                       </em>
                     </p>
                   </td>
@@ -66184,8 +66184,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-85.1">
-          <h3>8.26. The complex type <code>complexType[siri:ConnectionTimetableCapabilitiesResponseStructure]/ConnectionTimetablePermissions#complexType (typedef-85.1)</code>
+        <div class="sect2" id="local-type.typedef-83.1">
+          <h3>8.26. The complex type <code>complexType[siri:ConnectionTimetableCapabilitiesResponseStructure]/ConnectionTimetablePermissions#complexType (typedef-83.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -66205,7 +66205,7 @@
                       <br/>
                       <code>  /ConnectionTimetablePermissions #complexType</code>
                       <br/>
-                      <code>  (typedef-85.1)</code>
+                      <code>  (typedef-83.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -66279,8 +66279,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-85.2">
-          <h3>8.27. The complex type <code>complexType[siri:ConnectionTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-85.2)</code>
+        <div class="sect2" id="local-type.typedef-83.2">
+          <h3>8.27. The complex type <code>complexType[siri:ConnectionTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-83.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -66300,7 +66300,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-85.2)</code>
+                      <code>  (typedef-83.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -66370,8 +66370,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-85.3">
-          <h3>8.28. The complex type <code>complexType[siri:ConnectionTimetableServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-85.3)</code>
+        <div class="sect2" id="local-type.typedef-83.3">
+          <h3>8.28. The complex type <code>complexType[siri:ConnectionTimetableServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-83.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -66391,7 +66391,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-85.3)</code>
+                      <code>  (typedef-83.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -67838,7 +67838,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.2" title="local-type: typedef-78.2">local-type: typedef-78.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.2" title="local-type: typedef-84.2">local-type: typedef-84.2</a>
                       </em>
                     </p>
                   </td>
@@ -67859,7 +67859,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.3" title="local-type: typedef-78.3">local-type: typedef-78.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.3" title="local-type: typedef-84.3">local-type: typedef-84.3</a>
                       </em>
                     </p>
                   </td>
@@ -67880,7 +67880,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.7" title="local-type: typedef-78.7">local-type: typedef-78.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.7" title="local-type: typedef-84.7">local-type: typedef-84.7</a>
                       </em>
                     </p>
                   </td>
@@ -67901,7 +67901,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.9" title="local-type: typedef-78.9">local-type: typedef-78.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.9" title="local-type: typedef-84.9">local-type: typedef-84.9</a>
                       </em>
                     </p>
                   </td>
@@ -67922,7 +67922,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.10" title="local-type: typedef-78.10">local-type: typedef-78.10</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.10" title="local-type: typedef-84.10">local-type: typedef-84.10</a>
                       </em>
                     </p>
                   </td>
@@ -68288,7 +68288,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.1" title="local-type: typedef-78.1">local-type: typedef-78.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.1" title="local-type: typedef-84.1">local-type: typedef-84.1</a>
                       </em>
                     </p>
                   </td>
@@ -69764,7 +69764,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.18" title="local-type: typedef-78.18">local-type: typedef-78.18</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.18" title="local-type: typedef-84.18">local-type: typedef-84.18</a>
                       </em>
                     </p>
                   </td>
@@ -69794,7 +69794,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.19" title="local-type: typedef-78.19">local-type: typedef-78.19</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.19" title="local-type: typedef-84.19">local-type: typedef-84.19</a>
                       </em>
                     </p>
                   </td>
@@ -69923,7 +69923,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.18" title="local-type: typedef-78.18">local-type: typedef-78.18</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.18" title="local-type: typedef-84.18">local-type: typedef-84.18</a>
                       </em>
                     </p>
                   </td>
@@ -69953,7 +69953,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.19" title="local-type: typedef-78.19">local-type: typedef-78.19</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.19" title="local-type: typedef-84.19">local-type: typedef-84.19</a>
                       </em>
                     </p>
                   </td>
@@ -71784,7 +71784,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.18" title="local-type: typedef-78.18">local-type: typedef-78.18</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.18" title="local-type: typedef-84.18">local-type: typedef-84.18</a>
                       </em>
                     </p>
                   </td>
@@ -71814,7 +71814,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.19" title="local-type: typedef-78.19">local-type: typedef-78.19</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.19" title="local-type: typedef-84.19">local-type: typedef-84.19</a>
                       </em>
                     </p>
                   </td>
@@ -72546,7 +72546,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.14" title="local-type: typedef-78.14">local-type: typedef-78.14</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.14" title="local-type: typedef-84.14">local-type: typedef-84.14</a>
                       </em>
                     </p>
                   </td>
@@ -73245,7 +73245,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.2" title="local-type: typedef-78.2">local-type: typedef-78.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.2" title="local-type: typedef-84.2">local-type: typedef-84.2</a>
                       </em>
                     </p>
                   </td>
@@ -73266,7 +73266,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.3" title="local-type: typedef-78.3">local-type: typedef-78.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.3" title="local-type: typedef-84.3">local-type: typedef-84.3</a>
                       </em>
                     </p>
                   </td>
@@ -73287,7 +73287,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.7" title="local-type: typedef-78.7">local-type: typedef-78.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.7" title="local-type: typedef-84.7">local-type: typedef-84.7</a>
                       </em>
                     </p>
                   </td>
@@ -73308,7 +73308,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.9" title="local-type: typedef-78.9">local-type: typedef-78.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.9" title="local-type: typedef-84.9">local-type: typedef-84.9</a>
                       </em>
                     </p>
                   </td>
@@ -73329,7 +73329,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.10" title="local-type: typedef-78.10">local-type: typedef-78.10</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.10" title="local-type: typedef-84.10">local-type: typedef-84.10</a>
                       </em>
                     </p>
                   </td>
@@ -73575,7 +73575,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.1" title="local-type: typedef-78.1">local-type: typedef-78.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.1" title="local-type: typedef-84.1">local-type: typedef-84.1</a>
                       </em>
                     </p>
                   </td>
@@ -74250,7 +74250,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.1" title="local-type: typedef-78.1">local-type: typedef-78.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.1" title="local-type: typedef-84.1">local-type: typedef-84.1</a>
                       </em>
                     </p>
                   </td>
@@ -74514,7 +74514,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.11" title="local-type: typedef-78.11">local-type: typedef-78.11</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.11" title="local-type: typedef-84.11">local-type: typedef-84.11</a>
                       </em>
                     </p>
                   </td>
@@ -74538,7 +74538,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.12" title="local-type: typedef-78.12">local-type: typedef-78.12</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.12" title="local-type: typedef-84.12">local-type: typedef-84.12</a>
                       </em>
                     </p>
                   </td>
@@ -74610,7 +74610,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.13" title="local-type: typedef-78.13">local-type: typedef-78.13</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.13" title="local-type: typedef-84.13">local-type: typedef-84.13</a>
                       </em>
                     </p>
                   </td>
@@ -74744,7 +74744,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-69.1" title="local-type: typedef-69.1">local-type: typedef-69.1</a>
                       </em>
                     </p>
                   </td>
@@ -74778,7 +74778,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-56.2" title="local-type: typedef-56.2">local-type: typedef-56.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-33.2" title="local-type: typedef-33.2">local-type: typedef-33.2</a>
                       </em>
                     </p>
                   </td>
@@ -74807,7 +74807,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-56.1" title="local-type: typedef-56.1">local-type: typedef-56.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-33.1" title="local-type: typedef-33.1">local-type: typedef-33.1</a>
                       </em>
                     </p>
                   </td>
@@ -75555,7 +75555,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.15" title="local-type: typedef-78.15">local-type: typedef-78.15</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.15" title="local-type: typedef-84.15">local-type: typedef-84.15</a>
                       </em>
                     </p>
                   </td>
@@ -76398,7 +76398,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.16" title="local-type: typedef-78.16">local-type: typedef-78.16</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.16" title="local-type: typedef-84.16">local-type: typedef-84.16</a>
                       </em>
                     </p>
                   </td>
@@ -76527,7 +76527,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.17" title="local-type: typedef-78.17">local-type: typedef-78.17</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.17" title="local-type: typedef-84.17">local-type: typedef-84.17</a>
                       </em>
                     </p>
                   </td>
@@ -79866,8 +79866,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.14">
-          <h3>9.83. The complex type <code>element[siri:ControlActionPermissions]#complexType (typedef-78.14)</code>
+        <div class="sect2" id="local-type.typedef-84.14">
+          <h3>9.83. The complex type <code>element[siri:ControlActionPermissions]#complexType (typedef-84.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -79887,7 +79887,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-78.14)</code>
+                      <code>  (typedef-84.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -79961,8 +79961,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.2">
-          <h3>9.84. The complex type <code>group[siri:ControlActionPayloadGroup]/controlActions#complexType (typedef-78.2)</code>
+        <div class="sect2" id="local-type.typedef-84.2">
+          <h3>9.84. The complex type <code>group[siri:ControlActionPayloadGroup]/controlActions#complexType (typedef-84.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -79982,7 +79982,7 @@
                       <br/>
                       <code>  /controlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-78.2)</code>
+                      <code>  (typedef-84.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -80024,8 +80024,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.3">
-          <h3>9.85. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions#complexType (typedef-78.3)</code>
+        <div class="sect2" id="local-type.typedef-84.3">
+          <h3>9.85. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions#complexType (typedef-84.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -80045,7 +80045,7 @@
                       <br/>
                       <code>  /groupsOfControlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-78.3)</code>
+                      <code>  (typedef-84.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -80075,7 +80075,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.4" title="local-type: typedef-78.4">local-type: typedef-78.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.4" title="local-type: typedef-84.4">local-type: typedef-84.4</a>
                       </em>
                     </p>
                   </td>
@@ -80087,8 +80087,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.4">
-          <h3>9.86. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions#complexType (typedef-78.4)</code>
+        <div class="sect2" id="local-type.typedef-84.4">
+          <h3>9.86. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions#complexType (typedef-84.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -80108,7 +80108,7 @@
                       <br/>
                       <code>  /groupsOfControlActions/GroupOfControlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-78.4)</code>
+                      <code>  (typedef-84.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -80278,7 +80278,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.5" title="local-type: typedef-78.5">local-type: typedef-78.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.5" title="local-type: typedef-84.5">local-type: typedef-84.5</a>
                       </em>
                     </p>
                   </td>
@@ -80302,7 +80302,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.6" title="local-type: typedef-78.6">local-type: typedef-78.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.6" title="local-type: typedef-84.6">local-type: typedef-84.6</a>
                       </em>
                     </p>
                   </td>
@@ -80314,8 +80314,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.5">
-          <h3>9.87. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions/AddedControlActions#complexType (typedef-78.5)</code>
+        <div class="sect2" id="local-type.typedef-84.5">
+          <h3>9.87. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions/AddedControlActions#complexType (typedef-84.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -80335,7 +80335,7 @@
                       <br/>
                       <code>  /groupsOfControlActions/GroupOfControlActions/AddedControlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-78.5)</code>
+                      <code>  (typedef-84.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -80377,8 +80377,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.6">
-          <h3>9.88. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions/RemovedControlActions#complexType (typedef-78.6)</code>
+        <div class="sect2" id="local-type.typedef-84.6">
+          <h3>9.88. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions/RemovedControlActions#complexType (typedef-84.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -80398,7 +80398,7 @@
                       <br/>
                       <code>  /groupsOfControlActions/GroupOfControlActions/RemovedControlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-78.6)</code>
+                      <code>  (typedef-84.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -80440,8 +80440,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.7">
-          <h3>9.89. The complex type <code>group[siri:ControlActionPayloadGroup]/revokedControlActions#complexType (typedef-78.7)</code>
+        <div class="sect2" id="local-type.typedef-84.7">
+          <h3>9.89. The complex type <code>group[siri:ControlActionPayloadGroup]/revokedControlActions#complexType (typedef-84.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -80461,7 +80461,7 @@
                       <br/>
                       <code>  /revokedControlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-78.7)</code>
+                      <code>  (typedef-84.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -80491,7 +80491,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.8" title="local-type: typedef-78.8">local-type: typedef-78.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.8" title="local-type: typedef-84.8">local-type: typedef-84.8</a>
                       </em>
                     </p>
                   </td>
@@ -80503,8 +80503,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.8">
-          <h3>9.90. The complex type <code>group[siri:ControlActionPayloadGroup]/revokedControlActions/RevokedControlAction#complexType (typedef-78.8)</code>
+        <div class="sect2" id="local-type.typedef-84.8">
+          <h3>9.90. The complex type <code>group[siri:ControlActionPayloadGroup]/revokedControlActions/RevokedControlAction#complexType (typedef-84.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -80524,7 +80524,7 @@
                       <br/>
                       <code>  /revokedControlActions/RevokedControlAction #complexType</code>
                       <br/>
-                      <code>  (typedef-78.8)</code>
+                      <code>  (typedef-84.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -80657,8 +80657,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.9">
-          <h3>9.91. The complex type <code>group[siri:ControlActionPayloadGroup]/driverMessages#complexType (typedef-78.9)</code>
+        <div class="sect2" id="local-type.typedef-84.9">
+          <h3>9.91. The complex type <code>group[siri:ControlActionPayloadGroup]/driverMessages#complexType (typedef-84.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -80678,7 +80678,7 @@
                       <br/>
                       <code>  /driverMessages #complexType</code>
                       <br/>
-                      <code>  (typedef-78.9)</code>
+                      <code>  (typedef-84.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -80720,8 +80720,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.10">
-          <h3>9.92. The complex type <code>group[siri:ControlActionPayloadGroup]/vehicleDetectings#complexType (typedef-78.10)</code>
+        <div class="sect2" id="local-type.typedef-84.10">
+          <h3>9.92. The complex type <code>group[siri:ControlActionPayloadGroup]/vehicleDetectings#complexType (typedef-84.10)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -80741,7 +80741,7 @@
                       <br/>
                       <code>  /vehicleDetectings #complexType</code>
                       <br/>
-                      <code>  (typedef-78.10)</code>
+                      <code>  (typedef-84.10)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -80783,8 +80783,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.1">
-          <h3>9.93. The complex type <code>group[siri:ControlActionTopicGroup]/Lines#complexType (typedef-78.1)</code>
+        <div class="sect2" id="local-type.typedef-84.1">
+          <h3>9.93. The complex type <code>group[siri:ControlActionTopicGroup]/Lines#complexType (typedef-84.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -80804,7 +80804,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-78.1)</code>
+                      <code>  (typedef-84.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -80846,8 +80846,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.18">
-          <h3>9.94. The complex type <code>group[siri:PartOfJourneyPatternScope]/SelectedCalls#complexType (typedef-78.18)</code>
+        <div class="sect2" id="local-type.typedef-84.18">
+          <h3>9.94. The complex type <code>group[siri:PartOfJourneyPatternScope]/SelectedCalls#complexType (typedef-84.18)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -80867,7 +80867,7 @@
                       <br/>
                       <code>  /SelectedCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-78.18)</code>
+                      <code>  (typedef-84.18)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -80909,8 +80909,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.19">
-          <h3>9.95. The complex type <code>group[siri:PartOfJourneyPatternScope]/CallsBetweenPoints#complexType (typedef-78.19)</code>
+        <div class="sect2" id="local-type.typedef-84.19">
+          <h3>9.95. The complex type <code>group[siri:PartOfJourneyPatternScope]/CallsBetweenPoints#complexType (typedef-84.19)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -80930,7 +80930,7 @@
                       <br/>
                       <code>  /CallsBetweenPoints #complexType</code>
                       <br/>
-                      <code>  (typedef-78.19)</code>
+                      <code>  (typedef-84.19)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81000,8 +81000,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.18">
-          <h3>9.96. The complex type <code>group[siri:PartOfJourneyPatternScope]/SelectedCalls#complexType (typedef-78.18)</code>
+        <div class="sect2" id="local-type.typedef-84.18">
+          <h3>9.96. The complex type <code>group[siri:PartOfJourneyPatternScope]/SelectedCalls#complexType (typedef-84.18)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81021,7 +81021,7 @@
                       <br/>
                       <code>  /SelectedCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-78.18)</code>
+                      <code>  (typedef-84.18)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81063,8 +81063,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.19">
-          <h3>9.97. The complex type <code>group[siri:PartOfJourneyPatternScope]/CallsBetweenPoints#complexType (typedef-78.19)</code>
+        <div class="sect2" id="local-type.typedef-84.19">
+          <h3>9.97. The complex type <code>group[siri:PartOfJourneyPatternScope]/CallsBetweenPoints#complexType (typedef-84.19)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81084,7 +81084,7 @@
                       <br/>
                       <code>  /CallsBetweenPoints #complexType</code>
                       <br/>
-                      <code>  (typedef-78.19)</code>
+                      <code>  (typedef-84.19)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81154,8 +81154,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.18">
-          <h3>9.98. The complex type <code>group[siri:PartOfJourneyPatternScope]/SelectedCalls#complexType (typedef-78.18)</code>
+        <div class="sect2" id="local-type.typedef-84.18">
+          <h3>9.98. The complex type <code>group[siri:PartOfJourneyPatternScope]/SelectedCalls#complexType (typedef-84.18)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81175,7 +81175,7 @@
                       <br/>
                       <code>  /SelectedCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-78.18)</code>
+                      <code>  (typedef-84.18)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81217,8 +81217,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.19">
-          <h3>9.99. The complex type <code>group[siri:PartOfJourneyPatternScope]/CallsBetweenPoints#complexType (typedef-78.19)</code>
+        <div class="sect2" id="local-type.typedef-84.19">
+          <h3>9.99. The complex type <code>group[siri:PartOfJourneyPatternScope]/CallsBetweenPoints#complexType (typedef-84.19)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81238,7 +81238,7 @@
                       <br/>
                       <code>  /CallsBetweenPoints #complexType</code>
                       <br/>
-                      <code>  (typedef-78.19)</code>
+                      <code>  (typedef-84.19)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81308,8 +81308,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.14">
-          <h3>9.100. The complex type <code>element[siri:ControlActionPermissions]#complexType (typedef-78.14)</code>
+        <div class="sect2" id="local-type.typedef-84.14">
+          <h3>9.100. The complex type <code>element[siri:ControlActionPermissions]#complexType (typedef-84.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81329,7 +81329,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-78.14)</code>
+                      <code>  (typedef-84.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81403,8 +81403,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.2">
-          <h3>9.101. The complex type <code>group[siri:ControlActionPayloadGroup]/controlActions#complexType (typedef-78.2)</code>
+        <div class="sect2" id="local-type.typedef-84.2">
+          <h3>9.101. The complex type <code>group[siri:ControlActionPayloadGroup]/controlActions#complexType (typedef-84.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81424,7 +81424,7 @@
                       <br/>
                       <code>  /controlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-78.2)</code>
+                      <code>  (typedef-84.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81466,8 +81466,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.3">
-          <h3>9.102. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions#complexType (typedef-78.3)</code>
+        <div class="sect2" id="local-type.typedef-84.3">
+          <h3>9.102. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions#complexType (typedef-84.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81487,7 +81487,7 @@
                       <br/>
                       <code>  /groupsOfControlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-78.3)</code>
+                      <code>  (typedef-84.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81517,7 +81517,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.4" title="local-type: typedef-78.4">local-type: typedef-78.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.4" title="local-type: typedef-84.4">local-type: typedef-84.4</a>
                       </em>
                     </p>
                   </td>
@@ -81529,8 +81529,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.4">
-          <h3>9.103. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions#complexType (typedef-78.4)</code>
+        <div class="sect2" id="local-type.typedef-84.4">
+          <h3>9.103. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions#complexType (typedef-84.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81550,7 +81550,7 @@
                       <br/>
                       <code>  /groupsOfControlActions/GroupOfControlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-78.4)</code>
+                      <code>  (typedef-84.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81720,7 +81720,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.5" title="local-type: typedef-78.5">local-type: typedef-78.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.5" title="local-type: typedef-84.5">local-type: typedef-84.5</a>
                       </em>
                     </p>
                   </td>
@@ -81744,7 +81744,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.6" title="local-type: typedef-78.6">local-type: typedef-78.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.6" title="local-type: typedef-84.6">local-type: typedef-84.6</a>
                       </em>
                     </p>
                   </td>
@@ -81756,8 +81756,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.5">
-          <h3>9.104. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions/AddedControlActions#complexType (typedef-78.5)</code>
+        <div class="sect2" id="local-type.typedef-84.5">
+          <h3>9.104. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions/AddedControlActions#complexType (typedef-84.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81777,7 +81777,7 @@
                       <br/>
                       <code>  /groupsOfControlActions/GroupOfControlActions/AddedControlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-78.5)</code>
+                      <code>  (typedef-84.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81819,8 +81819,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.6">
-          <h3>9.105. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions/RemovedControlActions#complexType (typedef-78.6)</code>
+        <div class="sect2" id="local-type.typedef-84.6">
+          <h3>9.105. The complex type <code>group[siri:ControlActionPayloadGroup]/groupsOfControlActions/GroupOfControlActions/RemovedControlActions#complexType (typedef-84.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81840,7 +81840,7 @@
                       <br/>
                       <code>  /groupsOfControlActions/GroupOfControlActions/RemovedControlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-78.6)</code>
+                      <code>  (typedef-84.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81882,8 +81882,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.7">
-          <h3>9.106. The complex type <code>group[siri:ControlActionPayloadGroup]/revokedControlActions#complexType (typedef-78.7)</code>
+        <div class="sect2" id="local-type.typedef-84.7">
+          <h3>9.106. The complex type <code>group[siri:ControlActionPayloadGroup]/revokedControlActions#complexType (typedef-84.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81903,7 +81903,7 @@
                       <br/>
                       <code>  /revokedControlActions #complexType</code>
                       <br/>
-                      <code>  (typedef-78.7)</code>
+                      <code>  (typedef-84.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -81933,7 +81933,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-78.8" title="local-type: typedef-78.8">local-type: typedef-78.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-84.8" title="local-type: typedef-84.8">local-type: typedef-84.8</a>
                       </em>
                     </p>
                   </td>
@@ -81945,8 +81945,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.8">
-          <h3>9.107. The complex type <code>group[siri:ControlActionPayloadGroup]/revokedControlActions/RevokedControlAction#complexType (typedef-78.8)</code>
+        <div class="sect2" id="local-type.typedef-84.8">
+          <h3>9.107. The complex type <code>group[siri:ControlActionPayloadGroup]/revokedControlActions/RevokedControlAction#complexType (typedef-84.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -81966,7 +81966,7 @@
                       <br/>
                       <code>  /revokedControlActions/RevokedControlAction #complexType</code>
                       <br/>
-                      <code>  (typedef-78.8)</code>
+                      <code>  (typedef-84.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -82099,8 +82099,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.9">
-          <h3>9.108. The complex type <code>group[siri:ControlActionPayloadGroup]/driverMessages#complexType (typedef-78.9)</code>
+        <div class="sect2" id="local-type.typedef-84.9">
+          <h3>9.108. The complex type <code>group[siri:ControlActionPayloadGroup]/driverMessages#complexType (typedef-84.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -82120,7 +82120,7 @@
                       <br/>
                       <code>  /driverMessages #complexType</code>
                       <br/>
-                      <code>  (typedef-78.9)</code>
+                      <code>  (typedef-84.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -82162,8 +82162,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.10">
-          <h3>9.109. The complex type <code>group[siri:ControlActionPayloadGroup]/vehicleDetectings#complexType (typedef-78.10)</code>
+        <div class="sect2" id="local-type.typedef-84.10">
+          <h3>9.109. The complex type <code>group[siri:ControlActionPayloadGroup]/vehicleDetectings#complexType (typedef-84.10)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -82183,7 +82183,7 @@
                       <br/>
                       <code>  /vehicleDetectings #complexType</code>
                       <br/>
-                      <code>  (typedef-78.10)</code>
+                      <code>  (typedef-84.10)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -82225,8 +82225,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.1">
-          <h3>9.110. The complex type <code>group[siri:ControlActionTopicGroup]/Lines#complexType (typedef-78.1)</code>
+        <div class="sect2" id="local-type.typedef-84.1">
+          <h3>9.110. The complex type <code>group[siri:ControlActionTopicGroup]/Lines#complexType (typedef-84.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -82246,7 +82246,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-78.1)</code>
+                      <code>  (typedef-84.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -82288,8 +82288,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.1">
-          <h3>9.111. The complex type <code>group[siri:ControlActionTopicGroup]/Lines#complexType (typedef-78.1)</code>
+        <div class="sect2" id="local-type.typedef-84.1">
+          <h3>9.111. The complex type <code>group[siri:ControlActionTopicGroup]/Lines#complexType (typedef-84.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -82309,7 +82309,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-78.1)</code>
+                      <code>  (typedef-84.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -82351,8 +82351,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.11">
-          <h3>9.112. The complex type <code>complexType[siri:ControlActionServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-78.11)</code>
+        <div class="sect2" id="local-type.typedef-84.11">
+          <h3>9.112. The complex type <code>complexType[siri:ControlActionServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-84.11)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -82372,7 +82372,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-78.11)</code>
+                      <code>  (typedef-84.11)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -82504,8 +82504,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.12">
-          <h3>9.113. The complex type <code>complexType[siri:ControlActionServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-78.12)</code>
+        <div class="sect2" id="local-type.typedef-84.12">
+          <h3>9.113. The complex type <code>complexType[siri:ControlActionServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-84.12)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -82525,7 +82525,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-78.12)</code>
+                      <code>  (typedef-84.12)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -82743,8 +82743,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.13">
-          <h3>9.114. The complex type <code>complexType[siri:ControlActionServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-78.13)</code>
+        <div class="sect2" id="local-type.typedef-84.13">
+          <h3>9.114. The complex type <code>complexType[siri:ControlActionServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-84.13)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -82764,7 +82764,7 @@
                       <br/>
                       <code>  /ResponseFeatures #complexType</code>
                       <br/>
-                      <code>  (typedef-78.13)</code>
+                      <code>  (typedef-84.13)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -82801,8 +82801,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-36.1">
-          <h3>9.115. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-36.1)</code>
+        <div class="sect2" id="local-type.typedef-69.1">
+          <h3>9.115. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-69.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -82822,7 +82822,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-36.1)</code>
+                      <code>  (typedef-69.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -82890,8 +82890,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-56.2">
-          <h3>9.116. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-56.2)</code>
+        <div class="sect2" id="local-type.typedef-33.2">
+          <h3>9.116. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-33.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -82911,7 +82911,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-56.2)</code>
+                      <code>  (typedef-33.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -82996,8 +82996,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-56.1">
-          <h3>9.117. The complex type <code>element[siri:LinePermissions]#complexType (typedef-56.1)</code>
+        <div class="sect2" id="local-type.typedef-33.1">
+          <h3>9.117. The complex type <code>element[siri:LinePermissions]#complexType (typedef-33.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -83017,7 +83017,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-56.1)</code>
+                      <code>  (typedef-33.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -83102,8 +83102,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.15">
-          <h3>9.118. The complex type <code>complexType[siri:ControlActionStructure]/SituationDescription#complexType (typedef-78.15)</code>
+        <div class="sect2" id="local-type.typedef-84.15">
+          <h3>9.118. The complex type <code>complexType[siri:ControlActionStructure]/SituationDescription#complexType (typedef-84.15)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -83123,7 +83123,7 @@
                       <br/>
                       <code>  /SituationDescription #complexType</code>
                       <br/>
-                      <code>  (typedef-78.15)</code>
+                      <code>  (typedef-84.15)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -83274,7 +83274,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.14" title="local-type: typedef-60.14">local-type: typedef-60.14</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.14" title="local-type: typedef-48.14">local-type: typedef-48.14</a>
                       </em>
                     </p>
                   </td>
@@ -83295,7 +83295,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.16" title="local-type: typedef-60.16">local-type: typedef-60.16</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.16" title="local-type: typedef-48.16">local-type: typedef-48.16</a>
                       </em>
                     </p>
                   </td>
@@ -83307,8 +83307,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.14">
-          <h3>9.119. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-60.14)</code>
+        <div class="sect2" id="local-type.typedef-48.14">
+          <h3>9.119. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-48.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -83328,7 +83328,7 @@
                       <br/>
                       <code>  /Images #complexType</code>
                       <br/>
-                      <code>  (typedef-60.14)</code>
+                      <code>  (typedef-48.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -83358,7 +83358,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.15" title="local-type: typedef-60.15">local-type: typedef-60.15</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.15" title="local-type: typedef-48.15">local-type: typedef-48.15</a>
                       </em>
                     </p>
                   </td>
@@ -83370,8 +83370,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.15">
-          <h3>9.120. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-60.15)</code>
+        <div class="sect2" id="local-type.typedef-48.15">
+          <h3>9.120. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-48.15)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -83391,7 +83391,7 @@
                       <br/>
                       <code>  /Images/Image #complexType</code>
                       <br/>
-                      <code>  (typedef-60.15)</code>
+                      <code>  (typedef-48.15)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -83506,8 +83506,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.16">
-          <h3>9.121. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-60.16)</code>
+        <div class="sect2" id="local-type.typedef-48.16">
+          <h3>9.121. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-48.16)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -83527,7 +83527,7 @@
                       <br/>
                       <code>  /InfoLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-60.16)</code>
+                      <code>  (typedef-48.16)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -83569,8 +83569,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.16">
-          <h3>9.122. The complex type <code>complexType[siri:DriverMessageStructure]/MessageContents#complexType (typedef-78.16)</code>
+        <div class="sect2" id="local-type.typedef-84.16">
+          <h3>9.122. The complex type <code>complexType[siri:DriverMessageStructure]/MessageContents#complexType (typedef-84.16)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -83590,7 +83590,7 @@
                       <br/>
                       <code>  /MessageContents #complexType</code>
                       <br/>
-                      <code>  (typedef-78.16)</code>
+                      <code>  (typedef-84.16)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -83632,8 +83632,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-78.17">
-          <h3>9.123. The complex type <code>complexType[siri:DriverMessageStructure]/DiverScope#complexType (typedef-78.17)</code>
+        <div class="sect2" id="local-type.typedef-84.17">
+          <h3>9.123. The complex type <code>complexType[siri:DriverMessageStructure]/DiverScope#complexType (typedef-84.17)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -83653,7 +83653,7 @@
                       <br/>
                       <code>  /DiverScope #complexType</code>
                       <br/>
-                      <code>  (typedef-78.17)</code>
+                      <code>  (typedef-84.17)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -86146,7 +86146,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.1" title="local-type: typedef-72.1">local-type: typedef-72.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.1" title="local-type: typedef-77.1">local-type: typedef-77.1</a>
                       </em>
                     </p>
                   </td>
@@ -86208,7 +86208,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
                       </em>
                     </p>
                   </td>
@@ -86976,7 +86976,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.1" title="local-type: typedef-72.1">local-type: typedef-72.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.1" title="local-type: typedef-77.1">local-type: typedef-77.1</a>
                       </em>
                     </p>
                   </td>
@@ -87038,7 +87038,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-72.2" title="local-type: typedef-72.2">local-type: typedef-72.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
                       </em>
                     </p>
                   </td>
@@ -92058,8 +92058,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.2">
-          <h3>10.51. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-72.2)</code>
+        <div class="sect2" id="local-type.typedef-77.2">
+          <h3>10.51. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-77.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -92079,7 +92079,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.2)</code>
+                      <code>  (typedef-77.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -92297,8 +92297,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.1">
-          <h3>10.52. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-72.1)</code>
+        <div class="sect2" id="local-type.typedef-77.1">
+          <h3>10.52. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-77.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -92318,7 +92318,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.1)</code>
+                      <code>  (typedef-77.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -92708,8 +92708,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.1">
-          <h3>10.53. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-72.1)</code>
+        <div class="sect2" id="local-type.typedef-77.1">
+          <h3>10.53. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-77.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -92729,7 +92729,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.1)</code>
+                      <code>  (typedef-77.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -93119,8 +93119,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.2">
-          <h3>10.54. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-72.2)</code>
+        <div class="sect2" id="local-type.typedef-77.2">
+          <h3>10.54. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-77.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -93140,7 +93140,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.2)</code>
+                      <code>  (typedef-77.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -93358,8 +93358,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.1">
-          <h3>10.55. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-72.1)</code>
+        <div class="sect2" id="local-type.typedef-77.1">
+          <h3>10.55. The complex type <code>element[siri:StopPointsRequest]#complexType (typedef-77.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -93379,7 +93379,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.1)</code>
+                      <code>  (typedef-77.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -93769,8 +93769,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-72.2">
-          <h3>10.56. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-72.2)</code>
+        <div class="sect2" id="local-type.typedef-77.2">
+          <h3>10.56. The complex type <code>element[siri:ServiceFeaturesRequest]#complexType (typedef-77.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -93790,7 +93790,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-72.2)</code>
+                      <code>  (typedef-77.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -94843,7 +94843,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-86.1" title="local-type: typedef-86.1">local-type: typedef-86.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-82.1" title="local-type: typedef-82.1">local-type: typedef-82.1</a>
                       </em>
                     </p>
                   </td>
@@ -95336,7 +95336,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-86.4" title="local-type: typedef-86.4">local-type: typedef-86.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-82.4" title="local-type: typedef-82.4">local-type: typedef-82.4</a>
                       </em>
                     </p>
                   </td>
@@ -96250,7 +96250,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-86.1" title="local-type: typedef-86.1">local-type: typedef-86.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-82.1" title="local-type: typedef-82.1">local-type: typedef-82.1</a>
                       </em>
                     </p>
                   </td>
@@ -96583,7 +96583,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-86.2" title="local-type: typedef-86.2">local-type: typedef-86.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-82.2" title="local-type: typedef-82.2">local-type: typedef-82.2</a>
                       </em>
                     </p>
                   </td>
@@ -96607,7 +96607,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-86.3" title="local-type: typedef-86.3">local-type: typedef-86.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-82.3" title="local-type: typedef-82.3">local-type: typedef-82.3</a>
                       </em>
                     </p>
                   </td>
@@ -97123,8 +97123,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-86.4">
-          <h3>11.23. The complex type <code>element[siri:EstimatedTimetablePermissions]#complexType (typedef-86.4)</code>
+        <div class="sect2" id="local-type.typedef-82.4">
+          <h3>11.23. The complex type <code>element[siri:EstimatedTimetablePermissions]#complexType (typedef-82.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -97144,7 +97144,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-86.4)</code>
+                      <code>  (typedef-82.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -97218,8 +97218,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-86.1">
-          <h3>11.24. The complex type <code>group[siri:EstimatedTimetableTopicGroup]/Lines#complexType (typedef-86.1)</code>
+        <div class="sect2" id="local-type.typedef-82.1">
+          <h3>11.24. The complex type <code>group[siri:EstimatedTimetableTopicGroup]/Lines#complexType (typedef-82.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -97239,7 +97239,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-86.1)</code>
+                      <code>  (typedef-82.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -97281,8 +97281,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-86.4">
-          <h3>11.25. The complex type <code>element[siri:EstimatedTimetablePermissions]#complexType (typedef-86.4)</code>
+        <div class="sect2" id="local-type.typedef-82.4">
+          <h3>11.25. The complex type <code>element[siri:EstimatedTimetablePermissions]#complexType (typedef-82.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -97302,7 +97302,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-86.4)</code>
+                      <code>  (typedef-82.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -97376,8 +97376,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-86.1">
-          <h3>11.26. The complex type <code>group[siri:EstimatedTimetableTopicGroup]/Lines#complexType (typedef-86.1)</code>
+        <div class="sect2" id="local-type.typedef-82.1">
+          <h3>11.26. The complex type <code>group[siri:EstimatedTimetableTopicGroup]/Lines#complexType (typedef-82.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -97397,7 +97397,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-86.1)</code>
+                      <code>  (typedef-82.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -97439,8 +97439,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-86.2">
-          <h3>11.27. The complex type <code>complexType[siri:EstimatedTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-86.2)</code>
+        <div class="sect2" id="local-type.typedef-82.2">
+          <h3>11.27. The complex type <code>complexType[siri:EstimatedTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-82.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -97460,7 +97460,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-86.2)</code>
+                      <code>  (typedef-82.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -97650,8 +97650,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-86.3">
-          <h3>11.28. The complex type <code>complexType[siri:EstimatedTimetableServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-86.3)</code>
+        <div class="sect2" id="local-type.typedef-82.3">
+          <h3>11.28. The complex type <code>complexType[siri:EstimatedTimetableServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-82.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -97671,7 +97671,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-86.3)</code>
+                      <code>  (typedef-82.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -99582,7 +99582,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.5" title="local-type: typedef-75.5">local-type: typedef-75.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.5" title="local-type: typedef-80.5">local-type: typedef-80.5</a>
                       </em>
                     </p>
                   </td>
@@ -100779,7 +100779,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.1" title="local-type: typedef-75.1">local-type: typedef-75.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.1" title="local-type: typedef-80.1">local-type: typedef-80.1</a>
                       </em>
                     </p>
                   </td>
@@ -100803,7 +100803,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.2" title="local-type: typedef-75.2">local-type: typedef-75.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.2" title="local-type: typedef-80.2">local-type: typedef-80.2</a>
                       </em>
                     </p>
                   </td>
@@ -100851,7 +100851,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.3" title="local-type: typedef-75.3">local-type: typedef-75.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.3" title="local-type: typedef-80.3">local-type: typedef-80.3</a>
                       </em>
                     </p>
                   </td>
@@ -100875,7 +100875,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-75.4" title="local-type: typedef-75.4">local-type: typedef-75.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-80.4" title="local-type: typedef-80.4">local-type: typedef-80.4</a>
                       </em>
                     </p>
                   </td>
@@ -101034,7 +101034,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-69.1" title="local-type: typedef-69.1">local-type: typedef-69.1</a>
                       </em>
                     </p>
                   </td>
@@ -101068,7 +101068,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-56.2" title="local-type: typedef-56.2">local-type: typedef-56.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-33.2" title="local-type: typedef-33.2">local-type: typedef-33.2</a>
                       </em>
                     </p>
                   </td>
@@ -101097,7 +101097,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-56.1" title="local-type: typedef-56.1">local-type: typedef-56.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-33.1" title="local-type: typedef-33.1">local-type: typedef-33.1</a>
                       </em>
                     </p>
                   </td>
@@ -101353,8 +101353,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.5">
-          <h3>12.24. The complex type <code>element[siri:FacilityMonitoringPermissions]#complexType (typedef-75.5)</code>
+        <div class="sect2" id="local-type.typedef-80.5">
+          <h3>12.24. The complex type <code>element[siri:FacilityMonitoringPermissions]#complexType (typedef-80.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -101374,7 +101374,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-75.5)</code>
+                      <code>  (typedef-80.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -101448,8 +101448,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.5">
-          <h3>12.25. The complex type <code>element[siri:FacilityMonitoringPermissions]#complexType (typedef-75.5)</code>
+        <div class="sect2" id="local-type.typedef-80.5">
+          <h3>12.25. The complex type <code>element[siri:FacilityMonitoringPermissions]#complexType (typedef-80.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -101469,7 +101469,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-75.5)</code>
+                      <code>  (typedef-80.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -101543,8 +101543,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.1">
-          <h3>12.26. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-75.1)</code>
+        <div class="sect2" id="local-type.typedef-80.1">
+          <h3>12.26. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-80.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -101564,7 +101564,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-75.1)</code>
+                      <code>  (typedef-80.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -101829,8 +101829,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.2">
-          <h3>12.27. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-75.2)</code>
+        <div class="sect2" id="local-type.typedef-80.2">
+          <h3>12.27. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-80.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -101850,7 +101850,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-75.2)</code>
+                      <code>  (typedef-80.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -102022,8 +102022,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.3">
-          <h3>12.28. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/AccessControl#complexType (typedef-75.3)</code>
+        <div class="sect2" id="local-type.typedef-80.3">
+          <h3>12.28. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/AccessControl#complexType (typedef-80.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -102043,7 +102043,7 @@
                       <br/>
                       <code>  /AccessControl #complexType</code>
                       <br/>
-                      <code>  (typedef-75.3)</code>
+                      <code>  (typedef-80.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -102144,8 +102144,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-75.4">
-          <h3>12.29. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-75.4)</code>
+        <div class="sect2" id="local-type.typedef-80.4">
+          <h3>12.29. The complex type <code>complexType[siri:FacilityMonitoringServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-80.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -102165,7 +102165,7 @@
                       <br/>
                       <code>  /ResponseFeatures #complexType</code>
                       <br/>
-                      <code>  (typedef-75.4)</code>
+                      <code>  (typedef-80.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -102225,8 +102225,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-36.1">
-          <h3>12.30. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-36.1)</code>
+        <div class="sect2" id="local-type.typedef-69.1">
+          <h3>12.30. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-69.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -102246,7 +102246,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-36.1)</code>
+                      <code>  (typedef-69.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -102314,8 +102314,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-56.2">
-          <h3>12.31. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-56.2)</code>
+        <div class="sect2" id="local-type.typedef-33.2">
+          <h3>12.31. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-33.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -102335,7 +102335,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-56.2)</code>
+                      <code>  (typedef-33.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -102420,8 +102420,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-56.1">
-          <h3>12.32. The complex type <code>element[siri:LinePermissions]#complexType (typedef-56.1)</code>
+        <div class="sect2" id="local-type.typedef-33.1">
+          <h3>12.32. The complex type <code>element[siri:LinePermissions]#complexType (typedef-33.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -102441,7 +102441,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-56.1)</code>
+                      <code>  (typedef-33.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -103620,7 +103620,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-76.2" title="local-type: typedef-76.2">local-type: typedef-76.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-86.2" title="local-type: typedef-86.2">local-type: typedef-86.2</a>
                       </em>
                     </p>
                   </td>
@@ -104563,7 +104563,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-76.1" title="local-type: typedef-76.1">local-type: typedef-76.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-86.1" title="local-type: typedef-86.1">local-type: typedef-86.1</a>
                       </em>
                     </p>
                   </td>
@@ -104745,7 +104745,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-69.1" title="local-type: typedef-69.1">local-type: typedef-69.1</a>
                       </em>
                     </p>
                   </td>
@@ -104778,7 +104778,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-76.3" title="local-type: typedef-76.3">local-type: typedef-76.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-86.3" title="local-type: typedef-86.3">local-type: typedef-86.3</a>
                       </em>
                     </p>
                   </td>
@@ -105604,8 +105604,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-76.2">
-          <h3>13.29. The complex type <code>element[siri:GeneralMessagePermissions]#complexType (typedef-76.2)</code>
+        <div class="sect2" id="local-type.typedef-86.2">
+          <h3>13.29. The complex type <code>element[siri:GeneralMessagePermissions]#complexType (typedef-86.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -105625,7 +105625,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-76.2)</code>
+                      <code>  (typedef-86.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -105699,8 +105699,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-76.2">
-          <h3>13.30. The complex type <code>element[siri:GeneralMessagePermissions]#complexType (typedef-76.2)</code>
+        <div class="sect2" id="local-type.typedef-86.2">
+          <h3>13.30. The complex type <code>element[siri:GeneralMessagePermissions]#complexType (typedef-86.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -105720,7 +105720,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-76.2)</code>
+                      <code>  (typedef-86.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -105794,8 +105794,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-76.1">
-          <h3>13.31. The complex type <code>complexType[siri:GeneralMessageServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-76.1)</code>
+        <div class="sect2" id="local-type.typedef-86.1">
+          <h3>13.31. The complex type <code>complexType[siri:GeneralMessageServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-86.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -105815,7 +105815,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-76.1)</code>
+                      <code>  (typedef-86.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -105881,8 +105881,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-36.1">
-          <h3>13.32. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-36.1)</code>
+        <div class="sect2" id="local-type.typedef-69.1">
+          <h3>13.32. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-69.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -105902,7 +105902,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-36.1)</code>
+                      <code>  (typedef-69.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -105970,8 +105970,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-76.3">
-          <h3>13.33. The complex type <code>complexType[siri:GeneralMessageServicePermissionStructure]/InfoChannelPermissions#complexType (typedef-76.3)</code>
+        <div class="sect2" id="local-type.typedef-86.3">
+          <h3>13.33. The complex type <code>complexType[siri:GeneralMessageServicePermissionStructure]/InfoChannelPermissions#complexType (typedef-86.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -105991,7 +105991,7 @@
                       <br/>
                       <code>  /InfoChannelPermissions #complexType</code>
                       <br/>
-                      <code>  (typedef-76.3)</code>
+                      <code>  (typedef-86.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -106876,7 +106876,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -109621,7 +109621,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -109642,7 +109642,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -109663,7 +109663,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -109748,7 +109748,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -109769,7 +109769,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -110014,7 +110014,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -110197,7 +110197,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-57.6" title="local-type: typedef-57.6">local-type: typedef-57.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.6" title="local-type: typedef-50.6">local-type: typedef-50.6</a>
                       </em>
                     </p>
                   </td>
@@ -110218,7 +110218,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-57.7" title="local-type: typedef-57.7">local-type: typedef-57.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.7" title="local-type: typedef-50.7">local-type: typedef-50.7</a>
                       </em>
                     </p>
                   </td>
@@ -110242,7 +110242,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.2" title="local-type: typedef-50.2">local-type: typedef-50.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.2" title="local-type: typedef-35.2">local-type: typedef-35.2</a>
                       </em>
                     </p>
                   </td>
@@ -110263,7 +110263,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.3" title="local-type: typedef-50.3">local-type: typedef-50.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.3" title="local-type: typedef-35.3">local-type: typedef-35.3</a>
                       </em>
                     </p>
                   </td>
@@ -110284,7 +110284,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.4" title="local-type: typedef-50.4">local-type: typedef-50.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.4" title="local-type: typedef-35.4">local-type: typedef-35.4</a>
                       </em>
                     </p>
                   </td>
@@ -110312,7 +110312,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-61.1" title="local-type: typedef-61.1">local-type: typedef-61.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-32.1" title="local-type: typedef-32.1">local-type: typedef-32.1</a>
                       </em>
                     </p>
                   </td>
@@ -111027,7 +111027,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-61.2" title="local-type: typedef-61.2">local-type: typedef-61.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-32.2" title="local-type: typedef-32.2">local-type: typedef-32.2</a>
                       </em>
                     </p>
                   </td>
@@ -113062,8 +113062,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-57.6">
-          <h3>14.37. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-57.6)</code>
+        <div class="sect2" id="local-type.typedef-50.6">
+          <h3>14.37. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-50.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -113083,7 +113083,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-57.6)</code>
+                      <code>  (typedef-50.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -113125,8 +113125,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-57.7">
-          <h3>14.38. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/JourneyParts#complexType (typedef-57.7)</code>
+        <div class="sect2" id="local-type.typedef-50.7">
+          <h3>14.38. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/JourneyParts#complexType (typedef-50.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -113146,7 +113146,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-57.7)</code>
+                      <code>  (typedef-50.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -113188,8 +113188,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.2">
-          <h3>14.39. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-50.2)</code>
+        <div class="sect2" id="local-type.typedef-35.2">
+          <h3>14.39. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-35.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -113209,7 +113209,7 @@
                       <br/>
                       <code>  /TrainElements #complexType</code>
                       <br/>
-                      <code>  (typedef-50.2)</code>
+                      <code>  (typedef-35.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -113296,8 +113296,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.3">
-          <h3>14.40. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-50.3)</code>
+        <div class="sect2" id="local-type.typedef-35.3">
+          <h3>14.40. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-35.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -113317,7 +113317,7 @@
                       <br/>
                       <code>  /Trains #complexType</code>
                       <br/>
-                      <code>  (typedef-50.3)</code>
+                      <code>  (typedef-35.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -113404,8 +113404,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.4">
-          <h3>14.41. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-50.4)</code>
+        <div class="sect2" id="local-type.typedef-35.4">
+          <h3>14.41. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-35.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -113425,7 +113425,7 @@
                       <br/>
                       <code>  /CompoundTrains #complexType</code>
                       <br/>
-                      <code>  (typedef-50.4)</code>
+                      <code>  (typedef-35.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -113512,8 +113512,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-61.1">
-          <h3>14.42. The complex type <code>complexType[siri:DatedVehicleJourneyStructure]/DatedCalls#complexType (typedef-61.1)</code>
+        <div class="sect2" id="local-type.typedef-32.1">
+          <h3>14.42. The complex type <code>complexType[siri:DatedVehicleJourneyStructure]/DatedCalls#complexType (typedef-32.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -113533,7 +113533,7 @@
                       <br/>
                       <code>  /DatedCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-61.1)</code>
+                      <code>  (typedef-32.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -113576,8 +113576,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-61.2">
-          <h3>14.43. The complex type <code>complexType[siri:RemovedDatedVehicleJourneyStructure]/TrainNumbers#complexType (typedef-61.2)</code>
+        <div class="sect2" id="local-type.typedef-32.2">
+          <h3>14.43. The complex type <code>complexType[siri:RemovedDatedVehicleJourneyStructure]/TrainNumbers#complexType (typedef-32.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -113597,7 +113597,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-61.2)</code>
+                      <code>  (typedef-32.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -117940,7 +117940,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -117961,7 +117961,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -117982,7 +117982,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -118067,7 +118067,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -118088,7 +118088,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -119056,7 +119056,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-57.4" title="local-type: typedef-57.4">local-type: typedef-57.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.4" title="local-type: typedef-50.4">local-type: typedef-50.4</a>
                       </em>
                     </p>
                   </td>
@@ -119077,7 +119077,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-57.5" title="local-type: typedef-57.5">local-type: typedef-57.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.5" title="local-type: typedef-50.5">local-type: typedef-50.5</a>
                       </em>
                     </p>
                   </td>
@@ -119101,7 +119101,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.2" title="local-type: typedef-50.2">local-type: typedef-50.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.2" title="local-type: typedef-35.2">local-type: typedef-35.2</a>
                       </em>
                     </p>
                   </td>
@@ -119122,7 +119122,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.3" title="local-type: typedef-50.3">local-type: typedef-50.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.3" title="local-type: typedef-35.3">local-type: typedef-35.3</a>
                       </em>
                     </p>
                   </td>
@@ -119143,7 +119143,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.4" title="local-type: typedef-50.4">local-type: typedef-50.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.4" title="local-type: typedef-35.4">local-type: typedef-35.4</a>
                       </em>
                     </p>
                   </td>
@@ -119167,7 +119167,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-66.1" title="local-type: typedef-66.1">local-type: typedef-66.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-41.1" title="local-type: typedef-41.1">local-type: typedef-41.1</a>
                       </em>
                     </p>
                   </td>
@@ -119191,7 +119191,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-66.2" title="local-type: typedef-66.2">local-type: typedef-66.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-41.2" title="local-type: typedef-41.2">local-type: typedef-41.2</a>
                       </em>
                     </p>
                   </td>
@@ -120573,8 +120573,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-57.4">
-          <h3>15.16. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-57.4)</code>
+        <div class="sect2" id="local-type.typedef-50.4">
+          <h3>15.16. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-50.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -120594,7 +120594,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-57.4)</code>
+                      <code>  (typedef-50.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -120636,8 +120636,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-57.5">
-          <h3>15.17. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-57.5)</code>
+        <div class="sect2" id="local-type.typedef-50.5">
+          <h3>15.17. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-50.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -120657,7 +120657,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-57.5)</code>
+                      <code>  (typedef-50.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -120699,8 +120699,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.2">
-          <h3>15.18. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-50.2)</code>
+        <div class="sect2" id="local-type.typedef-35.2">
+          <h3>15.18. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-35.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -120720,7 +120720,7 @@
                       <br/>
                       <code>  /TrainElements #complexType</code>
                       <br/>
-                      <code>  (typedef-50.2)</code>
+                      <code>  (typedef-35.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -120807,8 +120807,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.3">
-          <h3>15.19. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-50.3)</code>
+        <div class="sect2" id="local-type.typedef-35.3">
+          <h3>15.19. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-35.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -120828,7 +120828,7 @@
                       <br/>
                       <code>  /Trains #complexType</code>
                       <br/>
-                      <code>  (typedef-50.3)</code>
+                      <code>  (typedef-35.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -120915,8 +120915,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.4">
-          <h3>15.20. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-50.4)</code>
+        <div class="sect2" id="local-type.typedef-35.4">
+          <h3>15.20. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-35.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -120936,7 +120936,7 @@
                       <br/>
                       <code>  /CompoundTrains #complexType</code>
                       <br/>
-                      <code>  (typedef-50.4)</code>
+                      <code>  (typedef-35.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -121023,8 +121023,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-66.1">
-          <h3>15.21. The complex type <code>complexType[siri:EstimatedVehicleJourneyStructure]/RecordedCalls#complexType (typedef-66.1)</code>
+        <div class="sect2" id="local-type.typedef-41.1">
+          <h3>15.21. The complex type <code>complexType[siri:EstimatedVehicleJourneyStructure]/RecordedCalls#complexType (typedef-41.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -121044,7 +121044,7 @@
                       <br/>
                       <code>  /RecordedCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-66.1)</code>
+                      <code>  (typedef-41.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -121087,8 +121087,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-66.2">
-          <h3>15.22. The complex type <code>complexType[siri:EstimatedVehicleJourneyStructure]/EstimatedCalls#complexType (typedef-66.2)</code>
+        <div class="sect2" id="local-type.typedef-41.2">
+          <h3>15.22. The complex type <code>complexType[siri:EstimatedVehicleJourneyStructure]/EstimatedCalls#complexType (typedef-41.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -121108,7 +121108,7 @@
                       <br/>
                       <code>  /EstimatedCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-66.2)</code>
+                      <code>  (typedef-41.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -126262,7 +126262,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-59.2" title="local-type: typedef-59.2">local-type: typedef-59.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-46.2" title="local-type: typedef-46.2">local-type: typedef-46.2</a>
                       </em>
                     </p>
                   </td>
@@ -126283,7 +126283,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-59.3" title="local-type: typedef-59.3">local-type: typedef-59.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-46.3" title="local-type: typedef-46.3">local-type: typedef-46.3</a>
                       </em>
                     </p>
                   </td>
@@ -126980,7 +126980,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-59.6" title="local-type: typedef-59.6">local-type: typedef-59.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-46.6" title="local-type: typedef-46.6">local-type: typedef-46.6</a>
                       </em>
                     </p>
                   </td>
@@ -127264,7 +127264,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-59.5" title="local-type: typedef-59.5">local-type: typedef-59.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-46.5" title="local-type: typedef-46.5">local-type: typedef-46.5</a>
                       </em>
                     </p>
                   </td>
@@ -128199,7 +128199,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-59.1" title="local-type: typedef-59.1">local-type: typedef-59.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-46.1" title="local-type: typedef-46.1">local-type: typedef-46.1</a>
                       </em>
                     </p>
                   </td>
@@ -128319,7 +128319,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-59.2" title="local-type: typedef-59.2">local-type: typedef-59.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-46.2" title="local-type: typedef-46.2">local-type: typedef-46.2</a>
                       </em>
                     </p>
                   </td>
@@ -128340,7 +128340,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-59.3" title="local-type: typedef-59.3">local-type: typedef-59.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-46.3" title="local-type: typedef-46.3">local-type: typedef-46.3</a>
                       </em>
                     </p>
                   </td>
@@ -128751,7 +128751,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-59.4" title="local-type: typedef-59.4">local-type: typedef-59.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-46.4" title="local-type: typedef-46.4">local-type: typedef-46.4</a>
                       </em>
                     </p>
                   </td>
@@ -129258,8 +129258,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-59.2">
-          <h3>17.32. The complex type <code>group[siri:FacilityAccessibilityGroup]/Limitations#complexType (typedef-59.2)</code>
+        <div class="sect2" id="local-type.typedef-46.2">
+          <h3>17.32. The complex type <code>group[siri:FacilityAccessibilityGroup]/Limitations#complexType (typedef-46.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -129279,7 +129279,7 @@
                       <br/>
                       <code>  /Limitations #complexType</code>
                       <br/>
-                      <code>  (typedef-59.2)</code>
+                      <code>  (typedef-46.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -129435,8 +129435,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-59.3">
-          <h3>17.33. The complex type <code>group[siri:FacilityAccessibilityGroup]/Suitabilities#complexType (typedef-59.3)</code>
+        <div class="sect2" id="local-type.typedef-46.3">
+          <h3>17.33. The complex type <code>group[siri:FacilityAccessibilityGroup]/Suitabilities#complexType (typedef-46.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -129456,7 +129456,7 @@
                       <br/>
                       <code>  /Suitabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-59.3)</code>
+                      <code>  (typedef-46.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -129498,8 +129498,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-59.6">
-          <h3>17.34. The complex type <code>complexType[siri:EquipmentAvailabilityStructure]/EquipmentFeatures#complexType (typedef-59.6)</code>
+        <div class="sect2" id="local-type.typedef-46.6">
+          <h3>17.34. The complex type <code>complexType[siri:EquipmentAvailabilityStructure]/EquipmentFeatures#complexType (typedef-46.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -129519,7 +129519,7 @@
                       <br/>
                       <code>  /EquipmentFeatures #complexType</code>
                       <br/>
-                      <code>  (typedef-59.6)</code>
+                      <code>  (typedef-46.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -129561,8 +129561,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-59.5">
-          <h3>17.35. The complex type <code>complexType[siri:FacilityConditionStructure]/MonitoredCounting#complexType (typedef-59.5)</code>
+        <div class="sect2" id="local-type.typedef-46.5">
+          <h3>17.35. The complex type <code>complexType[siri:FacilityConditionStructure]/MonitoredCounting#complexType (typedef-46.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -129582,7 +129582,7 @@
                       <br/>
                       <code>  /MonitoredCounting #complexType</code>
                       <br/>
-                      <code>  (typedef-59.5)</code>
+                      <code>  (typedef-46.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -129838,7 +129838,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-59.4" title="local-type: typedef-59.4">local-type: typedef-59.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-46.4" title="local-type: typedef-46.4">local-type: typedef-46.4</a>
                       </em>
                     </p>
                   </td>
@@ -129875,8 +129875,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-59.4">
-          <h3>17.36. The complex type <code>complexType[siri:MonitoredCountingStructure]/CountedItemsIdList#complexType (typedef-59.4)</code>
+        <div class="sect2" id="local-type.typedef-46.4">
+          <h3>17.36. The complex type <code>complexType[siri:MonitoredCountingStructure]/CountedItemsIdList#complexType (typedef-46.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -129896,7 +129896,7 @@
                       <br/>
                       <code>  /CountedItemsIdList #complexType</code>
                       <br/>
-                      <code>  (typedef-59.4)</code>
+                      <code>  (typedef-46.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -129939,8 +129939,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-59.1">
-          <h3>17.37. The complex type <code>complexType[siri:FacilityStructure]/Features#complexType (typedef-59.1)</code>
+        <div class="sect2" id="local-type.typedef-46.1">
+          <h3>17.37. The complex type <code>complexType[siri:FacilityStructure]/Features#complexType (typedef-46.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -129960,7 +129960,7 @@
                       <br/>
                       <code>  /Features #complexType</code>
                       <br/>
-                      <code>  (typedef-59.1)</code>
+                      <code>  (typedef-46.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -130002,8 +130002,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-59.2">
-          <h3>17.38. The complex type <code>group[siri:FacilityAccessibilityGroup]/Limitations#complexType (typedef-59.2)</code>
+        <div class="sect2" id="local-type.typedef-46.2">
+          <h3>17.38. The complex type <code>group[siri:FacilityAccessibilityGroup]/Limitations#complexType (typedef-46.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -130023,7 +130023,7 @@
                       <br/>
                       <code>  /Limitations #complexType</code>
                       <br/>
-                      <code>  (typedef-59.2)</code>
+                      <code>  (typedef-46.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -130179,8 +130179,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-59.3">
-          <h3>17.39. The complex type <code>group[siri:FacilityAccessibilityGroup]/Suitabilities#complexType (typedef-59.3)</code>
+        <div class="sect2" id="local-type.typedef-46.3">
+          <h3>17.39. The complex type <code>group[siri:FacilityAccessibilityGroup]/Suitabilities#complexType (typedef-46.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -130200,7 +130200,7 @@
                       <br/>
                       <code>  /Suitabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-59.3)</code>
+                      <code>  (typedef-46.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -130242,8 +130242,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-59.4">
-          <h3>17.40. The complex type <code>complexType[siri:MonitoredCountingStructure]/CountedItemsIdList#complexType (typedef-59.4)</code>
+        <div class="sect2" id="local-type.typedef-46.4">
+          <h3>17.40. The complex type <code>complexType[siri:MonitoredCountingStructure]/CountedItemsIdList#complexType (typedef-46.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -130263,7 +130263,7 @@
                       <br/>
                       <code>  /CountedItemsIdList #complexType</code>
                       <br/>
-                      <code>  (typedef-59.4)</code>
+                      <code>  (typedef-46.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -131046,7 +131046,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -131067,7 +131067,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -131088,7 +131088,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -131173,7 +131173,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -131194,7 +131194,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -131731,12 +131731,12 @@
               <tbody>
                 <tr>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-24.1" class="tableblock">
+                    <p id="local-type.typedef-1.1" class="tableblock">
                       <code>attribute[lang]</code>
                       <br/>
                       <code>  #simpleType</code>
                       <br/>
-                      <code>  (typedef-24.1)</code>
+                      <code>  (typedef-1.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -135073,7 +135073,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -135094,7 +135094,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -135115,7 +135115,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -135200,7 +135200,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -135221,7 +135221,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -135393,7 +135393,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.2" title="local-type: typedef-50.2">local-type: typedef-50.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.2" title="local-type: typedef-35.2">local-type: typedef-35.2</a>
                       </em>
                     </p>
                   </td>
@@ -135414,7 +135414,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.3" title="local-type: typedef-50.3">local-type: typedef-50.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.3" title="local-type: typedef-35.3">local-type: typedef-35.3</a>
                       </em>
                     </p>
                   </td>
@@ -135435,7 +135435,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.4" title="local-type: typedef-50.4">local-type: typedef-50.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.4" title="local-type: typedef-35.4">local-type: typedef-35.4</a>
                       </em>
                     </p>
                   </td>
@@ -135653,7 +135653,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.1" title="local-type: typedef-50.1">local-type: typedef-50.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.1" title="local-type: typedef-35.1">local-type: typedef-35.1</a>
                       </em>
                     </p>
                   </td>
@@ -139231,7 +139231,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.5" title="local-type: typedef-50.5">local-type: typedef-50.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.5" title="local-type: typedef-35.5">local-type: typedef-35.5</a>
                       </em>
                     </p>
                   </td>
@@ -139420,7 +139420,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -139441,7 +139441,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -139462,7 +139462,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -139547,7 +139547,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -139568,7 +139568,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -139612,7 +139612,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.7" title="local-type: typedef-50.7">local-type: typedef-50.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.7" title="local-type: typedef-35.7">local-type: typedef-35.7</a>
                       </em>
                     </p>
                   </td>
@@ -140220,7 +140220,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -140241,7 +140241,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -140262,7 +140262,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -140347,7 +140347,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -140368,7 +140368,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -140765,7 +140765,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.9" title="local-type: typedef-50.9">local-type: typedef-50.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.9" title="local-type: typedef-35.9">local-type: typedef-35.9</a>
                       </em>
                     </p>
                   </td>
@@ -140943,7 +140943,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.8" title="local-type: typedef-50.8">local-type: typedef-50.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.8" title="local-type: typedef-35.8">local-type: typedef-35.8</a>
                       </em>
                     </p>
                   </td>
@@ -141080,7 +141080,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.9" title="local-type: typedef-50.9">local-type: typedef-50.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.9" title="local-type: typedef-35.9">local-type: typedef-35.9</a>
                       </em>
                     </p>
                   </td>
@@ -141730,7 +141730,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.9" title="local-type: typedef-50.9">local-type: typedef-50.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.9" title="local-type: typedef-35.9">local-type: typedef-35.9</a>
                       </em>
                     </p>
                   </td>
@@ -141908,7 +141908,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.8" title="local-type: typedef-50.8">local-type: typedef-50.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.8" title="local-type: typedef-35.8">local-type: typedef-35.8</a>
                       </em>
                     </p>
                   </td>
@@ -141932,7 +141932,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.6" title="local-type: typedef-50.6">local-type: typedef-50.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.6" title="local-type: typedef-35.6">local-type: typedef-35.6</a>
                       </em>
                     </p>
                   </td>
@@ -143093,7 +143093,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.1" title="local-type: typedef-50.1">local-type: typedef-50.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.1" title="local-type: typedef-35.1">local-type: typedef-35.1</a>
                       </em>
                     </p>
                   </td>
@@ -146112,7 +146112,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.1" title="local-type: typedef-50.1">local-type: typedef-50.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.1" title="local-type: typedef-35.1">local-type: typedef-35.1</a>
                       </em>
                     </p>
                   </td>
@@ -147303,7 +147303,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.9" title="local-type: typedef-50.9">local-type: typedef-50.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.9" title="local-type: typedef-35.9">local-type: typedef-35.9</a>
                       </em>
                     </p>
                   </td>
@@ -147481,7 +147481,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.8" title="local-type: typedef-50.8">local-type: typedef-50.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.8" title="local-type: typedef-35.8">local-type: typedef-35.8</a>
                       </em>
                     </p>
                   </td>
@@ -147722,7 +147722,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -147743,7 +147743,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -147764,7 +147764,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -147849,7 +147849,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -147870,7 +147870,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -147914,7 +147914,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.7" title="local-type: typedef-50.7">local-type: typedef-50.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.7" title="local-type: typedef-35.7">local-type: typedef-35.7</a>
                       </em>
                     </p>
                   </td>
@@ -148162,7 +148162,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.9" title="local-type: typedef-50.9">local-type: typedef-50.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.9" title="local-type: typedef-35.9">local-type: typedef-35.9</a>
                       </em>
                     </p>
                   </td>
@@ -148340,7 +148340,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.8" title="local-type: typedef-50.8">local-type: typedef-50.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.8" title="local-type: typedef-35.8">local-type: typedef-35.8</a>
                       </em>
                     </p>
                   </td>
@@ -148406,7 +148406,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.5" title="local-type: typedef-50.5">local-type: typedef-50.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.5" title="local-type: typedef-35.5">local-type: typedef-35.5</a>
                       </em>
                     </p>
                   </td>
@@ -149260,8 +149260,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.2">
-          <h3>20.124. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-50.2)</code>
+        <div class="sect2" id="local-type.typedef-35.2">
+          <h3>20.124. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-35.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -149281,7 +149281,7 @@
                       <br/>
                       <code>  /TrainElements #complexType</code>
                       <br/>
-                      <code>  (typedef-50.2)</code>
+                      <code>  (typedef-35.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -149368,8 +149368,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.3">
-          <h3>20.125. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-50.3)</code>
+        <div class="sect2" id="local-type.typedef-35.3">
+          <h3>20.125. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-35.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -149389,7 +149389,7 @@
                       <br/>
                       <code>  /Trains #complexType</code>
                       <br/>
-                      <code>  (typedef-50.3)</code>
+                      <code>  (typedef-35.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -149476,8 +149476,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.4">
-          <h3>20.126. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-50.4)</code>
+        <div class="sect2" id="local-type.typedef-35.4">
+          <h3>20.126. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-35.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -149497,7 +149497,7 @@
                       <br/>
                       <code>  /CompoundTrains #complexType</code>
                       <br/>
-                      <code>  (typedef-50.4)</code>
+                      <code>  (typedef-35.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -149584,8 +149584,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.1">
-          <h3>20.127. The complex type <code>group[siri:JourneyRelationInfoGroup]/JourneyParts#complexType (typedef-50.1)</code>
+        <div class="sect2" id="local-type.typedef-35.1">
+          <h3>20.127. The complex type <code>group[siri:JourneyRelationInfoGroup]/JourneyParts#complexType (typedef-35.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -149605,7 +149605,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-50.1)</code>
+                      <code>  (typedef-35.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -149647,8 +149647,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.5">
-          <h3>20.128. The complex type <code>group[siri:TrainGroup]/TrainComponents#complexType (typedef-50.5)</code>
+        <div class="sect2" id="local-type.typedef-35.5">
+          <h3>20.128. The complex type <code>group[siri:TrainGroup]/TrainComponents#complexType (typedef-35.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -149668,7 +149668,7 @@
                       <br/>
                       <code>  /TrainComponents #complexType</code>
                       <br/>
-                      <code>  (typedef-50.5)</code>
+                      <code>  (typedef-35.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -149755,8 +149755,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.7">
-          <h3>20.129. The complex type <code>group[siri:TrainInCompoundTrainGroup]/Passages#complexType (typedef-50.7)</code>
+        <div class="sect2" id="local-type.typedef-35.7">
+          <h3>20.129. The complex type <code>group[siri:TrainInCompoundTrainGroup]/Passages#complexType (typedef-35.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -149776,7 +149776,7 @@
                       <br/>
                       <code>  /Passages #complexType</code>
                       <br/>
-                      <code>  (typedef-50.7)</code>
+                      <code>  (typedef-35.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -149818,8 +149818,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.9">
-          <h3>20.130. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-50.9)</code>
+        <div class="sect2" id="local-type.typedef-35.9">
+          <h3>20.130. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-35.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -149839,7 +149839,7 @@
                       <br/>
                       <code>  /MaximumPassengerCapacities #complexType</code>
                       <br/>
-                      <code>  (typedef-50.9)</code>
+                      <code>  (typedef-35.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -149881,8 +149881,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.8">
-          <h3>20.131. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-50.8)</code>
+        <div class="sect2" id="local-type.typedef-35.8">
+          <h3>20.131. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-35.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -149902,7 +149902,7 @@
                       <br/>
                       <code>  /Facilities #complexType</code>
                       <br/>
-                      <code>  (typedef-50.8)</code>
+                      <code>  (typedef-35.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -150022,8 +150022,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.9">
-          <h3>20.132. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-50.9)</code>
+        <div class="sect2" id="local-type.typedef-35.9">
+          <h3>20.132. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-35.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -150043,7 +150043,7 @@
                       <br/>
                       <code>  /MaximumPassengerCapacities #complexType</code>
                       <br/>
-                      <code>  (typedef-50.9)</code>
+                      <code>  (typedef-35.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -150085,8 +150085,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.9">
-          <h3>20.133. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-50.9)</code>
+        <div class="sect2" id="local-type.typedef-35.9">
+          <h3>20.133. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-35.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -150106,7 +150106,7 @@
                       <br/>
                       <code>  /MaximumPassengerCapacities #complexType</code>
                       <br/>
-                      <code>  (typedef-50.9)</code>
+                      <code>  (typedef-35.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -150148,8 +150148,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.8">
-          <h3>20.134. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-50.8)</code>
+        <div class="sect2" id="local-type.typedef-35.8">
+          <h3>20.134. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-35.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -150169,7 +150169,7 @@
                       <br/>
                       <code>  /Facilities #complexType</code>
                       <br/>
-                      <code>  (typedef-50.8)</code>
+                      <code>  (typedef-35.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -150289,8 +150289,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.6">
-          <h3>20.135. The complex type <code>complexType[siri:CompoundTrainStructure]/TrainsInCompoundTrain#complexType (typedef-50.6)</code>
+        <div class="sect2" id="local-type.typedef-35.6">
+          <h3>20.135. The complex type <code>complexType[siri:CompoundTrainStructure]/TrainsInCompoundTrain#complexType (typedef-35.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -150310,7 +150310,7 @@
                       <br/>
                       <code>  /TrainsInCompoundTrain #complexType</code>
                       <br/>
-                      <code>  (typedef-50.6)</code>
+                      <code>  (typedef-35.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -150397,8 +150397,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.1">
-          <h3>20.136. The complex type <code>group[siri:JourneyRelationInfoGroup]/JourneyParts#complexType (typedef-50.1)</code>
+        <div class="sect2" id="local-type.typedef-35.1">
+          <h3>20.136. The complex type <code>group[siri:JourneyRelationInfoGroup]/JourneyParts#complexType (typedef-35.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -150418,7 +150418,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-50.1)</code>
+                      <code>  (typedef-35.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -150460,8 +150460,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.1">
-          <h3>20.137. The complex type <code>group[siri:JourneyRelationInfoGroup]/JourneyParts#complexType (typedef-50.1)</code>
+        <div class="sect2" id="local-type.typedef-35.1">
+          <h3>20.137. The complex type <code>group[siri:JourneyRelationInfoGroup]/JourneyParts#complexType (typedef-35.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -150481,7 +150481,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-50.1)</code>
+                      <code>  (typedef-35.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -150523,8 +150523,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.9">
-          <h3>20.138. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-50.9)</code>
+        <div class="sect2" id="local-type.typedef-35.9">
+          <h3>20.138. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-35.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -150544,7 +150544,7 @@
                       <br/>
                       <code>  /MaximumPassengerCapacities #complexType</code>
                       <br/>
-                      <code>  (typedef-50.9)</code>
+                      <code>  (typedef-35.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -150586,8 +150586,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.8">
-          <h3>20.139. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-50.8)</code>
+        <div class="sect2" id="local-type.typedef-35.8">
+          <h3>20.139. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-35.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -150607,7 +150607,7 @@
                       <br/>
                       <code>  /Facilities #complexType</code>
                       <br/>
-                      <code>  (typedef-50.8)</code>
+                      <code>  (typedef-35.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -150727,8 +150727,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.7">
-          <h3>20.140. The complex type <code>group[siri:TrainInCompoundTrainGroup]/Passages#complexType (typedef-50.7)</code>
+        <div class="sect2" id="local-type.typedef-35.7">
+          <h3>20.140. The complex type <code>group[siri:TrainInCompoundTrainGroup]/Passages#complexType (typedef-35.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -150748,7 +150748,7 @@
                       <br/>
                       <code>  /Passages #complexType</code>
                       <br/>
-                      <code>  (typedef-50.7)</code>
+                      <code>  (typedef-35.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -150790,8 +150790,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.9">
-          <h3>20.141. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-50.9)</code>
+        <div class="sect2" id="local-type.typedef-35.9">
+          <h3>20.141. The complex type <code>group[siri:VehicleTypePropertiesGroup]/MaximumPassengerCapacities#complexType (typedef-35.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -150811,7 +150811,7 @@
                       <br/>
                       <code>  /MaximumPassengerCapacities #complexType</code>
                       <br/>
-                      <code>  (typedef-50.9)</code>
+                      <code>  (typedef-35.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -150853,8 +150853,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.8">
-          <h3>20.142. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-50.8)</code>
+        <div class="sect2" id="local-type.typedef-35.8">
+          <h3>20.142. The complex type <code>group[siri:VehicleTypeGroup]/Facilities#complexType (typedef-35.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -150874,7 +150874,7 @@
                       <br/>
                       <code>  /Facilities #complexType</code>
                       <br/>
-                      <code>  (typedef-50.8)</code>
+                      <code>  (typedef-35.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -150994,8 +150994,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.5">
-          <h3>20.143. The complex type <code>group[siri:TrainGroup]/TrainComponents#complexType (typedef-50.5)</code>
+        <div class="sect2" id="local-type.typedef-35.5">
+          <h3>20.143. The complex type <code>group[siri:TrainGroup]/TrainComponents#complexType (typedef-35.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -151015,7 +151015,7 @@
                       <br/>
                       <code>  /TrainComponents #complexType</code>
                       <br/>
-                      <code>  (typedef-50.5)</code>
+                      <code>  (typedef-35.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -156132,7 +156132,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-69.1" title="local-type: typedef-69.1">local-type: typedef-69.1</a>
                       </em>
                     </p>
                   </td>
@@ -156166,7 +156166,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-56.2" title="local-type: typedef-56.2">local-type: typedef-56.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-33.2" title="local-type: typedef-33.2">local-type: typedef-33.2</a>
                       </em>
                     </p>
                   </td>
@@ -156195,7 +156195,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-56.1" title="local-type: typedef-56.1">local-type: typedef-56.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-33.1" title="local-type: typedef-33.1">local-type: typedef-33.1</a>
                       </em>
                     </p>
                   </td>
@@ -156224,7 +156224,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-56.3" title="local-type: typedef-56.3">local-type: typedef-56.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-33.3" title="local-type: typedef-33.3">local-type: typedef-33.3</a>
                       </em>
                     </p>
                   </td>
@@ -156776,8 +156776,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-56.3">
-          <h3>22.31. The complex type <code>element[siri:ConnectionLinkPermissions]#complexType (typedef-56.3)</code>
+        <div class="sect2" id="local-type.typedef-33.3">
+          <h3>22.31. The complex type <code>element[siri:ConnectionLinkPermissions]#complexType (typedef-33.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -156797,7 +156797,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-56.3)</code>
+                      <code>  (typedef-33.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -156882,8 +156882,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-56.1">
-          <h3>22.32. The complex type <code>element[siri:LinePermissions]#complexType (typedef-56.1)</code>
+        <div class="sect2" id="local-type.typedef-33.1">
+          <h3>22.32. The complex type <code>element[siri:LinePermissions]#complexType (typedef-33.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -156903,7 +156903,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-56.1)</code>
+                      <code>  (typedef-33.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -156988,8 +156988,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-56.2">
-          <h3>22.33. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-56.2)</code>
+        <div class="sect2" id="local-type.typedef-33.2">
+          <h3>22.33. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-33.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -157009,7 +157009,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-56.2)</code>
+                      <code>  (typedef-33.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -157094,8 +157094,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-36.1">
-          <h3>22.34. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-36.1)</code>
+        <div class="sect2" id="local-type.typedef-69.1">
+          <h3>22.34. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-69.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -157115,7 +157115,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-36.1)</code>
+                      <code>  (typedef-69.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -157183,8 +157183,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-56.2">
-          <h3>22.35. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-56.2)</code>
+        <div class="sect2" id="local-type.typedef-33.2">
+          <h3>22.35. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-33.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -157204,7 +157204,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-56.2)</code>
+                      <code>  (typedef-33.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -157289,8 +157289,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-56.1">
-          <h3>22.36. The complex type <code>element[siri:LinePermissions]#complexType (typedef-56.1)</code>
+        <div class="sect2" id="local-type.typedef-33.1">
+          <h3>22.36. The complex type <code>element[siri:LinePermissions]#complexType (typedef-33.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -157310,7 +157310,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-56.1)</code>
+                      <code>  (typedef-33.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -157395,8 +157395,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-56.3">
-          <h3>22.37. The complex type <code>element[siri:ConnectionLinkPermissions]#complexType (typedef-56.3)</code>
+        <div class="sect2" id="local-type.typedef-33.3">
+          <h3>22.37. The complex type <code>element[siri:ConnectionLinkPermissions]#complexType (typedef-33.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -157416,7 +157416,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-56.3)</code>
+                      <code>  (typedef-33.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -163629,7 +163629,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-57.6" title="local-type: typedef-57.6">local-type: typedef-57.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.6" title="local-type: typedef-50.6">local-type: typedef-50.6</a>
                       </em>
                     </p>
                   </td>
@@ -163650,7 +163650,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-57.7" title="local-type: typedef-57.7">local-type: typedef-57.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.7" title="local-type: typedef-50.7">local-type: typedef-50.7</a>
                       </em>
                     </p>
                   </td>
@@ -163674,7 +163674,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.2" title="local-type: typedef-50.2">local-type: typedef-50.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.2" title="local-type: typedef-35.2">local-type: typedef-35.2</a>
                       </em>
                     </p>
                   </td>
@@ -163695,7 +163695,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.3" title="local-type: typedef-50.3">local-type: typedef-50.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.3" title="local-type: typedef-35.3">local-type: typedef-35.3</a>
                       </em>
                     </p>
                   </td>
@@ -163716,7 +163716,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.4" title="local-type: typedef-50.4">local-type: typedef-50.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.4" title="local-type: typedef-35.4">local-type: typedef-35.4</a>
                       </em>
                     </p>
                   </td>
@@ -166439,7 +166439,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-57.1" title="local-type: typedef-57.1">local-type: typedef-57.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.1" title="local-type: typedef-50.1">local-type: typedef-50.1</a>
                       </em>
                     </p>
                   </td>
@@ -166460,7 +166460,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-57.2" title="local-type: typedef-57.2">local-type: typedef-57.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.2" title="local-type: typedef-50.2">local-type: typedef-50.2</a>
                       </em>
                     </p>
                   </td>
@@ -166481,7 +166481,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-57.3" title="local-type: typedef-57.3">local-type: typedef-57.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.3" title="local-type: typedef-50.3">local-type: typedef-50.3</a>
                       </em>
                     </p>
                   </td>
@@ -167586,7 +167586,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-57.4" title="local-type: typedef-57.4">local-type: typedef-57.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.4" title="local-type: typedef-50.4">local-type: typedef-50.4</a>
                       </em>
                     </p>
                   </td>
@@ -167607,7 +167607,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-57.5" title="local-type: typedef-57.5">local-type: typedef-57.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.5" title="local-type: typedef-50.5">local-type: typedef-50.5</a>
                       </em>
                     </p>
                   </td>
@@ -167631,7 +167631,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.2" title="local-type: typedef-50.2">local-type: typedef-50.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.2" title="local-type: typedef-35.2">local-type: typedef-35.2</a>
                       </em>
                     </p>
                   </td>
@@ -167652,7 +167652,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.3" title="local-type: typedef-50.3">local-type: typedef-50.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.3" title="local-type: typedef-35.3">local-type: typedef-35.3</a>
                       </em>
                     </p>
                   </td>
@@ -167673,7 +167673,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.4" title="local-type: typedef-50.4">local-type: typedef-50.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.4" title="local-type: typedef-35.4">local-type: typedef-35.4</a>
                       </em>
                     </p>
                   </td>
@@ -169991,7 +169991,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -170012,7 +170012,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -170033,7 +170033,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -170118,7 +170118,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -170139,7 +170139,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -171016,7 +171016,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-57.4" title="local-type: typedef-57.4">local-type: typedef-57.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.4" title="local-type: typedef-50.4">local-type: typedef-50.4</a>
                       </em>
                     </p>
                   </td>
@@ -171037,7 +171037,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-57.5" title="local-type: typedef-57.5">local-type: typedef-57.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.5" title="local-type: typedef-50.5">local-type: typedef-50.5</a>
                       </em>
                     </p>
                   </td>
@@ -171061,7 +171061,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.2" title="local-type: typedef-50.2">local-type: typedef-50.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.2" title="local-type: typedef-35.2">local-type: typedef-35.2</a>
                       </em>
                     </p>
                   </td>
@@ -171082,7 +171082,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.3" title="local-type: typedef-50.3">local-type: typedef-50.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.3" title="local-type: typedef-35.3">local-type: typedef-35.3</a>
                       </em>
                     </p>
                   </td>
@@ -171103,7 +171103,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.4" title="local-type: typedef-50.4">local-type: typedef-50.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.4" title="local-type: typedef-35.4">local-type: typedef-35.4</a>
                       </em>
                     </p>
                   </td>
@@ -171765,8 +171765,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-57.6">
-          <h3>24.23. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-57.6)</code>
+        <div class="sect2" id="local-type.typedef-50.6">
+          <h3>24.23. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-50.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -171786,7 +171786,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-57.6)</code>
+                      <code>  (typedef-50.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -171828,8 +171828,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-57.7">
-          <h3>24.24. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/JourneyParts#complexType (typedef-57.7)</code>
+        <div class="sect2" id="local-type.typedef-50.7">
+          <h3>24.24. The complex type <code>group[siri:DatedTrainOperationalInfoGroup]/JourneyParts#complexType (typedef-50.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -171849,7 +171849,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-57.7)</code>
+                      <code>  (typedef-50.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -171891,8 +171891,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.2">
-          <h3>24.25. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-50.2)</code>
+        <div class="sect2" id="local-type.typedef-35.2">
+          <h3>24.25. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-35.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -171912,7 +171912,7 @@
                       <br/>
                       <code>  /TrainElements #complexType</code>
                       <br/>
-                      <code>  (typedef-50.2)</code>
+                      <code>  (typedef-35.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -171999,8 +171999,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.3">
-          <h3>24.26. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-50.3)</code>
+        <div class="sect2" id="local-type.typedef-35.3">
+          <h3>24.26. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-35.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172020,7 +172020,7 @@
                       <br/>
                       <code>  /Trains #complexType</code>
                       <br/>
-                      <code>  (typedef-50.3)</code>
+                      <code>  (typedef-35.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -172107,8 +172107,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.4">
-          <h3>24.27. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-50.4)</code>
+        <div class="sect2" id="local-type.typedef-35.4">
+          <h3>24.27. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-35.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172128,7 +172128,7 @@
                       <br/>
                       <code>  /CompoundTrains #complexType</code>
                       <br/>
-                      <code>  (typedef-50.4)</code>
+                      <code>  (typedef-35.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -172215,8 +172215,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-57.1">
-          <h3>24.28. The complex type <code>group[siri:ServicePointsGroup]/Origin#complexType (typedef-57.1)</code>
+        <div class="sect2" id="local-type.typedef-50.1">
+          <h3>24.28. The complex type <code>group[siri:ServicePointsGroup]/Origin#complexType (typedef-50.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172236,7 +172236,7 @@
                       <br/>
                       <code>  /Origin #complexType</code>
                       <br/>
-                      <code>  (typedef-57.1)</code>
+                      <code>  (typedef-50.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -172300,8 +172300,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-57.2">
-          <h3>24.29. The complex type <code>group[siri:ServicePointsGroup]/Via#complexType (typedef-57.2)</code>
+        <div class="sect2" id="local-type.typedef-50.2">
+          <h3>24.29. The complex type <code>group[siri:ServicePointsGroup]/Via#complexType (typedef-50.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172321,7 +172321,7 @@
                       <br/>
                       <code>  /Via #complexType</code>
                       <br/>
-                      <code>  (typedef-57.2)</code>
+                      <code>  (typedef-50.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -172408,8 +172408,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-57.3">
-          <h3>24.30. The complex type <code>group[siri:ServicePointsGroup]/Destination#complexType (typedef-57.3)</code>
+        <div class="sect2" id="local-type.typedef-50.3">
+          <h3>24.30. The complex type <code>group[siri:ServicePointsGroup]/Destination#complexType (typedef-50.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172429,7 +172429,7 @@
                       <br/>
                       <code>  /Destination #complexType</code>
                       <br/>
-                      <code>  (typedef-57.3)</code>
+                      <code>  (typedef-50.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -172493,8 +172493,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-57.4">
-          <h3>24.31. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-57.4)</code>
+        <div class="sect2" id="local-type.typedef-50.4">
+          <h3>24.31. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-50.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172514,7 +172514,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-57.4)</code>
+                      <code>  (typedef-50.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -172556,8 +172556,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-57.5">
-          <h3>24.32. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-57.5)</code>
+        <div class="sect2" id="local-type.typedef-50.5">
+          <h3>24.32. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-50.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172577,7 +172577,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-57.5)</code>
+                      <code>  (typedef-50.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -172619,8 +172619,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.2">
-          <h3>24.33. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-50.2)</code>
+        <div class="sect2" id="local-type.typedef-35.2">
+          <h3>24.33. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-35.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172640,7 +172640,7 @@
                       <br/>
                       <code>  /TrainElements #complexType</code>
                       <br/>
-                      <code>  (typedef-50.2)</code>
+                      <code>  (typedef-35.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -172727,8 +172727,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.3">
-          <h3>24.34. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-50.3)</code>
+        <div class="sect2" id="local-type.typedef-35.3">
+          <h3>24.34. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-35.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172748,7 +172748,7 @@
                       <br/>
                       <code>  /Trains #complexType</code>
                       <br/>
-                      <code>  (typedef-50.3)</code>
+                      <code>  (typedef-35.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -172835,8 +172835,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.4">
-          <h3>24.35. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-50.4)</code>
+        <div class="sect2" id="local-type.typedef-35.4">
+          <h3>24.35. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-35.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172856,7 +172856,7 @@
                       <br/>
                       <code>  /CompoundTrains #complexType</code>
                       <br/>
-                      <code>  (typedef-50.4)</code>
+                      <code>  (typedef-35.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -172943,8 +172943,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-57.4">
-          <h3>24.36. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-57.4)</code>
+        <div class="sect2" id="local-type.typedef-50.4">
+          <h3>24.36. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-50.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -172964,7 +172964,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-57.4)</code>
+                      <code>  (typedef-50.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -173006,8 +173006,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-57.5">
-          <h3>24.37. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-57.5)</code>
+        <div class="sect2" id="local-type.typedef-50.5">
+          <h3>24.37. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-50.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -173027,7 +173027,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-57.5)</code>
+                      <code>  (typedef-50.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -173069,8 +173069,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.2">
-          <h3>24.38. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-50.2)</code>
+        <div class="sect2" id="local-type.typedef-35.2">
+          <h3>24.38. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-35.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -173090,7 +173090,7 @@
                       <br/>
                       <code>  /TrainElements #complexType</code>
                       <br/>
-                      <code>  (typedef-50.2)</code>
+                      <code>  (typedef-35.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -173177,8 +173177,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.3">
-          <h3>24.39. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-50.3)</code>
+        <div class="sect2" id="local-type.typedef-35.3">
+          <h3>24.39. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-35.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -173198,7 +173198,7 @@
                       <br/>
                       <code>  /Trains #complexType</code>
                       <br/>
-                      <code>  (typedef-50.3)</code>
+                      <code>  (typedef-35.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -173285,8 +173285,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.4">
-          <h3>24.40. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-50.4)</code>
+        <div class="sect2" id="local-type.typedef-35.4">
+          <h3>24.40. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-35.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -173306,7 +173306,7 @@
                       <br/>
                       <code>  /CompoundTrains #complexType</code>
                       <br/>
-                      <code>  (typedef-50.4)</code>
+                      <code>  (typedef-35.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -178016,12 +178016,12 @@
                 </tr>
                 <tr>
                   <td colspan="1" rowspan="2" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-60.3" class="tableblock">
+                    <p id="local-type.typedef-48.3" class="tableblock">
                       <code>group[siri:ClassifierGroup]</code>
                       <br/>
                       <code>  /ScopeType #simpleType</code>
                       <br/>
-                      <code>  (typedef-60.3)</code>
+                      <code>  (typedef-48.3)</code>
                     </p>
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
@@ -178202,12 +178202,12 @@
                 </tr>
                 <tr>
                   <td colspan="1" rowspan="2" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-60.1" class="tableblock">
+                    <p id="local-type.typedef-48.1" class="tableblock">
                       <code>group[siri:StatusGroup]</code>
                       <br/>
                       <code>  /Verification #simpleType</code>
                       <br/>
-                      <code>  (typedef-60.1)</code>
+                      <code>  (typedef-48.1)</code>
                     </p>
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
@@ -178268,12 +178268,12 @@
                 </tr>
                 <tr>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-24.1" class="tableblock">
+                    <p id="local-type.typedef-1.1" class="tableblock">
                       <code>attribute[lang]</code>
                       <br/>
                       <code>  #simpleType</code>
                       <br/>
-                      <code>  (typedef-24.1)</code>
+                      <code>  (typedef-1.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -178901,7 +178901,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-60.3" title="local-type: typedef-60.3">local-type: typedef-60.3</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-48.3" title="local-type: typedef-48.3">local-type: typedef-48.3</a>
                       </em>
                     </p>
                   </td>
@@ -178985,7 +178985,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.4" title="local-type: typedef-60.4">local-type: typedef-60.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.4" title="local-type: typedef-48.4">local-type: typedef-48.4</a>
                       </em>
                     </p>
                   </td>
@@ -179751,7 +179751,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.14" title="local-type: typedef-60.14">local-type: typedef-60.14</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.14" title="local-type: typedef-48.14">local-type: typedef-48.14</a>
                       </em>
                     </p>
                   </td>
@@ -179772,7 +179772,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.16" title="local-type: typedef-60.16">local-type: typedef-60.16</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.16" title="local-type: typedef-48.16">local-type: typedef-48.16</a>
                       </em>
                     </p>
                   </td>
@@ -179925,7 +179925,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-60.1" title="local-type: typedef-60.1">local-type: typedef-60.1</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-48.1" title="local-type: typedef-48.1">local-type: typedef-48.1</a>
                       </em>
                     </p>
                   </td>
@@ -180084,7 +180084,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.2" title="local-type: typedef-60.2">local-type: typedef-60.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.2" title="local-type: typedef-48.2">local-type: typedef-48.2</a>
                       </em>
                     </p>
                   </td>
@@ -180632,7 +180632,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-60.3" title="local-type: typedef-60.3">local-type: typedef-60.3</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-48.3" title="local-type: typedef-48.3">local-type: typedef-48.3</a>
                       </em>
                     </p>
                   </td>
@@ -180716,7 +180716,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.4" title="local-type: typedef-60.4">local-type: typedef-60.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.4" title="local-type: typedef-48.4">local-type: typedef-48.4</a>
                       </em>
                     </p>
                   </td>
@@ -180865,7 +180865,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.14" title="local-type: typedef-60.14">local-type: typedef-60.14</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.14" title="local-type: typedef-48.14">local-type: typedef-48.14</a>
                       </em>
                     </p>
                   </td>
@@ -180886,7 +180886,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.16" title="local-type: typedef-60.16">local-type: typedef-60.16</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.16" title="local-type: typedef-48.16">local-type: typedef-48.16</a>
                       </em>
                     </p>
                   </td>
@@ -181572,7 +181572,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-60.1" title="local-type: typedef-60.1">local-type: typedef-60.1</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-48.1" title="local-type: typedef-48.1">local-type: typedef-48.1</a>
                       </em>
                     </p>
                   </td>
@@ -181731,7 +181731,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.2" title="local-type: typedef-60.2">local-type: typedef-60.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.2" title="local-type: typedef-48.2">local-type: typedef-48.2</a>
                       </em>
                     </p>
                   </td>
@@ -182279,7 +182279,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-60.3" title="local-type: typedef-60.3">local-type: typedef-60.3</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-48.3" title="local-type: typedef-48.3">local-type: typedef-48.3</a>
                       </em>
                     </p>
                   </td>
@@ -182363,7 +182363,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.4" title="local-type: typedef-60.4">local-type: typedef-60.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.4" title="local-type: typedef-48.4">local-type: typedef-48.4</a>
                       </em>
                     </p>
                   </td>
@@ -182512,7 +182512,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.14" title="local-type: typedef-60.14">local-type: typedef-60.14</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.14" title="local-type: typedef-48.14">local-type: typedef-48.14</a>
                       </em>
                     </p>
                   </td>
@@ -182533,7 +182533,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.16" title="local-type: typedef-60.16">local-type: typedef-60.16</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.16" title="local-type: typedef-48.16">local-type: typedef-48.16</a>
                       </em>
                     </p>
                   </td>
@@ -182896,7 +182896,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-60.1" title="local-type: typedef-60.1">local-type: typedef-60.1</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-48.1" title="local-type: typedef-48.1">local-type: typedef-48.1</a>
                       </em>
                     </p>
                   </td>
@@ -183086,7 +183086,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.2" title="local-type: typedef-60.2">local-type: typedef-60.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.2" title="local-type: typedef-48.2">local-type: typedef-48.2</a>
                       </em>
                     </p>
                   </td>
@@ -183586,7 +183586,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.6" title="local-type: typedef-60.6">local-type: typedef-60.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.6" title="local-type: typedef-48.6">local-type: typedef-48.6</a>
                       </em>
                     </p>
                   </td>
@@ -183610,7 +183610,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.7" title="local-type: typedef-60.7">local-type: typedef-60.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.7" title="local-type: typedef-48.7">local-type: typedef-48.7</a>
                       </em>
                     </p>
                   </td>
@@ -183634,7 +183634,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.9" title="local-type: typedef-60.9">local-type: typedef-60.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.9" title="local-type: typedef-48.9">local-type: typedef-48.9</a>
                       </em>
                     </p>
                   </td>
@@ -183658,7 +183658,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.10" title="local-type: typedef-60.10">local-type: typedef-60.10</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.10" title="local-type: typedef-48.10">local-type: typedef-48.10</a>
                       </em>
                     </p>
                   </td>
@@ -183682,7 +183682,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.11" title="local-type: typedef-60.11">local-type: typedef-60.11</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.11" title="local-type: typedef-48.11">local-type: typedef-48.11</a>
                       </em>
                     </p>
                   </td>
@@ -183706,7 +183706,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.12" title="local-type: typedef-60.12">local-type: typedef-60.12</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.12" title="local-type: typedef-48.12">local-type: typedef-48.12</a>
                       </em>
                     </p>
                   </td>
@@ -183730,7 +183730,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.13" title="local-type: typedef-60.13">local-type: typedef-60.13</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.13" title="local-type: typedef-48.13">local-type: typedef-48.13</a>
                       </em>
                     </p>
                   </td>
@@ -185278,7 +185278,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.17" title="local-type: typedef-60.17">local-type: typedef-60.17</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.17" title="local-type: typedef-48.17">local-type: typedef-48.17</a>
                       </em>
                     </p>
                   </td>
@@ -185751,7 +185751,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-60.1" title="local-type: typedef-60.1">local-type: typedef-60.1</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-48.1" title="local-type: typedef-48.1">local-type: typedef-48.1</a>
                       </em>
                     </p>
                   </td>
@@ -185910,7 +185910,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.2" title="local-type: typedef-60.2">local-type: typedef-60.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.2" title="local-type: typedef-48.2">local-type: typedef-48.2</a>
                       </em>
                     </p>
                   </td>
@@ -186458,7 +186458,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-60.3" title="local-type: typedef-60.3">local-type: typedef-60.3</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-48.3" title="local-type: typedef-48.3">local-type: typedef-48.3</a>
                       </em>
                     </p>
                   </td>
@@ -186542,7 +186542,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.4" title="local-type: typedef-60.4">local-type: typedef-60.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.4" title="local-type: typedef-48.4">local-type: typedef-48.4</a>
                       </em>
                     </p>
                   </td>
@@ -186691,7 +186691,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.14" title="local-type: typedef-60.14">local-type: typedef-60.14</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.14" title="local-type: typedef-48.14">local-type: typedef-48.14</a>
                       </em>
                     </p>
                   </td>
@@ -186712,7 +186712,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.16" title="local-type: typedef-60.16">local-type: typedef-60.16</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.16" title="local-type: typedef-48.16">local-type: typedef-48.16</a>
                       </em>
                     </p>
                   </td>
@@ -187434,7 +187434,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-60.1" title="local-type: typedef-60.1">local-type: typedef-60.1</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-48.1" title="local-type: typedef-48.1">local-type: typedef-48.1</a>
                       </em>
                     </p>
                   </td>
@@ -187593,7 +187593,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.2" title="local-type: typedef-60.2">local-type: typedef-60.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.2" title="local-type: typedef-48.2">local-type: typedef-48.2</a>
                       </em>
                     </p>
                   </td>
@@ -188141,7 +188141,7 @@
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
                       <em>
-                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-60.3" title="local-type: typedef-60.3">local-type: typedef-60.3</a>
+                        <a shape="rect" href="/home/runner/work/SIRI/SIRI/docs/generated/contab/siri.enum-dict.html#local-enum.typedef-48.3" title="local-type: typedef-48.3">local-type: typedef-48.3</a>
                       </em>
                     </p>
                   </td>
@@ -188225,7 +188225,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.4" title="local-type: typedef-60.4">local-type: typedef-60.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.4" title="local-type: typedef-48.4">local-type: typedef-48.4</a>
                       </em>
                     </p>
                   </td>
@@ -188374,7 +188374,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.14" title="local-type: typedef-60.14">local-type: typedef-60.14</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.14" title="local-type: typedef-48.14">local-type: typedef-48.14</a>
                       </em>
                     </p>
                   </td>
@@ -188395,7 +188395,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.16" title="local-type: typedef-60.16">local-type: typedef-60.16</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.16" title="local-type: typedef-48.16">local-type: typedef-48.16</a>
                       </em>
                     </p>
                   </td>
@@ -189180,8 +189180,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.4">
-          <h3>27.53. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-60.4)</code>
+        <div class="sect2" id="local-type.typedef-48.4">
+          <h3>27.53. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-48.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -189201,7 +189201,7 @@
                       <br/>
                       <code>  /SecondaryReasons #complexType</code>
                       <br/>
-                      <code>  (typedef-60.4)</code>
+                      <code>  (typedef-48.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -189231,7 +189231,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.5" title="local-type: typedef-60.5">local-type: typedef-60.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.5" title="local-type: typedef-48.5">local-type: typedef-48.5</a>
                       </em>
                     </p>
                   </td>
@@ -189243,8 +189243,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.5">
-          <h3>27.54. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-60.5)</code>
+        <div class="sect2" id="local-type.typedef-48.5">
+          <h3>27.54. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-48.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -189264,7 +189264,7 @@
                       <br/>
                       <code>  /SecondaryReasons/Reason #complexType</code>
                       <br/>
-                      <code>  (typedef-60.5)</code>
+                      <code>  (typedef-48.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -189693,8 +189693,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.14">
-          <h3>27.55. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-60.14)</code>
+        <div class="sect2" id="local-type.typedef-48.14">
+          <h3>27.55. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-48.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -189714,7 +189714,7 @@
                       <br/>
                       <code>  /Images #complexType</code>
                       <br/>
-                      <code>  (typedef-60.14)</code>
+                      <code>  (typedef-48.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -189744,7 +189744,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.15" title="local-type: typedef-60.15">local-type: typedef-60.15</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.15" title="local-type: typedef-48.15">local-type: typedef-48.15</a>
                       </em>
                     </p>
                   </td>
@@ -189756,8 +189756,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.15">
-          <h3>27.56. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-60.15)</code>
+        <div class="sect2" id="local-type.typedef-48.15">
+          <h3>27.56. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-48.15)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -189777,7 +189777,7 @@
                       <br/>
                       <code>  /Images/Image #complexType</code>
                       <br/>
-                      <code>  (typedef-60.15)</code>
+                      <code>  (typedef-48.15)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -189892,8 +189892,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.16">
-          <h3>27.57. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-60.16)</code>
+        <div class="sect2" id="local-type.typedef-48.16">
+          <h3>27.57. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-48.16)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -189913,7 +189913,7 @@
                       <br/>
                       <code>  /InfoLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-60.16)</code>
+                      <code>  (typedef-48.16)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -189955,8 +189955,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.2">
-          <h3>27.58. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-60.2)</code>
+        <div class="sect2" id="local-type.typedef-48.2">
+          <h3>27.58. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-48.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -189976,7 +189976,7 @@
                       <br/>
                       <code>  /Repetitions #complexType</code>
                       <br/>
-                      <code>  (typedef-60.2)</code>
+                      <code>  (typedef-48.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -190020,8 +190020,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.4">
-          <h3>27.59. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-60.4)</code>
+        <div class="sect2" id="local-type.typedef-48.4">
+          <h3>27.59. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-48.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -190041,7 +190041,7 @@
                       <br/>
                       <code>  /SecondaryReasons #complexType</code>
                       <br/>
-                      <code>  (typedef-60.4)</code>
+                      <code>  (typedef-48.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -190071,7 +190071,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.5" title="local-type: typedef-60.5">local-type: typedef-60.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.5" title="local-type: typedef-48.5">local-type: typedef-48.5</a>
                       </em>
                     </p>
                   </td>
@@ -190083,8 +190083,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.5">
-          <h3>27.60. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-60.5)</code>
+        <div class="sect2" id="local-type.typedef-48.5">
+          <h3>27.60. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-48.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -190104,7 +190104,7 @@
                       <br/>
                       <code>  /SecondaryReasons/Reason #complexType</code>
                       <br/>
-                      <code>  (typedef-60.5)</code>
+                      <code>  (typedef-48.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -190533,8 +190533,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.14">
-          <h3>27.61. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-60.14)</code>
+        <div class="sect2" id="local-type.typedef-48.14">
+          <h3>27.61. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-48.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -190554,7 +190554,7 @@
                       <br/>
                       <code>  /Images #complexType</code>
                       <br/>
-                      <code>  (typedef-60.14)</code>
+                      <code>  (typedef-48.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -190584,7 +190584,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.15" title="local-type: typedef-60.15">local-type: typedef-60.15</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.15" title="local-type: typedef-48.15">local-type: typedef-48.15</a>
                       </em>
                     </p>
                   </td>
@@ -190596,8 +190596,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.15">
-          <h3>27.62. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-60.15)</code>
+        <div class="sect2" id="local-type.typedef-48.15">
+          <h3>27.62. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-48.15)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -190617,7 +190617,7 @@
                       <br/>
                       <code>  /Images/Image #complexType</code>
                       <br/>
-                      <code>  (typedef-60.15)</code>
+                      <code>  (typedef-48.15)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -190732,8 +190732,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.16">
-          <h3>27.63. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-60.16)</code>
+        <div class="sect2" id="local-type.typedef-48.16">
+          <h3>27.63. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-48.16)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -190753,7 +190753,7 @@
                       <br/>
                       <code>  /InfoLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-60.16)</code>
+                      <code>  (typedef-48.16)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -190795,8 +190795,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.2">
-          <h3>27.64. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-60.2)</code>
+        <div class="sect2" id="local-type.typedef-48.2">
+          <h3>27.64. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-48.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -190816,7 +190816,7 @@
                       <br/>
                       <code>  /Repetitions #complexType</code>
                       <br/>
-                      <code>  (typedef-60.2)</code>
+                      <code>  (typedef-48.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -190860,8 +190860,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.4">
-          <h3>27.65. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-60.4)</code>
+        <div class="sect2" id="local-type.typedef-48.4">
+          <h3>27.65. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-48.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -190881,7 +190881,7 @@
                       <br/>
                       <code>  /SecondaryReasons #complexType</code>
                       <br/>
-                      <code>  (typedef-60.4)</code>
+                      <code>  (typedef-48.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -190911,7 +190911,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.5" title="local-type: typedef-60.5">local-type: typedef-60.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.5" title="local-type: typedef-48.5">local-type: typedef-48.5</a>
                       </em>
                     </p>
                   </td>
@@ -190923,8 +190923,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.5">
-          <h3>27.66. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-60.5)</code>
+        <div class="sect2" id="local-type.typedef-48.5">
+          <h3>27.66. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-48.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -190944,7 +190944,7 @@
                       <br/>
                       <code>  /SecondaryReasons/Reason #complexType</code>
                       <br/>
-                      <code>  (typedef-60.5)</code>
+                      <code>  (typedef-48.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -191373,8 +191373,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.14">
-          <h3>27.67. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-60.14)</code>
+        <div class="sect2" id="local-type.typedef-48.14">
+          <h3>27.67. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-48.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -191394,7 +191394,7 @@
                       <br/>
                       <code>  /Images #complexType</code>
                       <br/>
-                      <code>  (typedef-60.14)</code>
+                      <code>  (typedef-48.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -191424,7 +191424,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.15" title="local-type: typedef-60.15">local-type: typedef-60.15</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.15" title="local-type: typedef-48.15">local-type: typedef-48.15</a>
                       </em>
                     </p>
                   </td>
@@ -191436,8 +191436,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.15">
-          <h3>27.68. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-60.15)</code>
+        <div class="sect2" id="local-type.typedef-48.15">
+          <h3>27.68. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-48.15)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -191457,7 +191457,7 @@
                       <br/>
                       <code>  /Images/Image #complexType</code>
                       <br/>
-                      <code>  (typedef-60.15)</code>
+                      <code>  (typedef-48.15)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -191572,8 +191572,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.16">
-          <h3>27.69. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-60.16)</code>
+        <div class="sect2" id="local-type.typedef-48.16">
+          <h3>27.69. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-48.16)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -191593,7 +191593,7 @@
                       <br/>
                       <code>  /InfoLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-60.16)</code>
+                      <code>  (typedef-48.16)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -191635,8 +191635,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.2">
-          <h3>27.70. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-60.2)</code>
+        <div class="sect2" id="local-type.typedef-48.2">
+          <h3>27.70. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-48.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -191656,7 +191656,7 @@
                       <br/>
                       <code>  /Repetitions #complexType</code>
                       <br/>
-                      <code>  (typedef-60.2)</code>
+                      <code>  (typedef-48.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -191700,8 +191700,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.6">
-          <h3>27.71. The complex type <code>complexType[siri:AffectsScopeStructure]/Operators#complexType (typedef-60.6)</code>
+        <div class="sect2" id="local-type.typedef-48.6">
+          <h3>27.71. The complex type <code>complexType[siri:AffectsScopeStructure]/Operators#complexType (typedef-48.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -191721,7 +191721,7 @@
                       <br/>
                       <code>  /Operators #complexType</code>
                       <br/>
-                      <code>  (typedef-60.6)</code>
+                      <code>  (typedef-48.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -191807,8 +191807,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.7">
-          <h3>27.72. The complex type <code>complexType[siri:AffectsScopeStructure]/Networks#complexType (typedef-60.7)</code>
+        <div class="sect2" id="local-type.typedef-48.7">
+          <h3>27.72. The complex type <code>complexType[siri:AffectsScopeStructure]/Networks#complexType (typedef-48.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -191828,7 +191828,7 @@
                       <br/>
                       <code>  /Networks #complexType</code>
                       <br/>
-                      <code>  (typedef-60.7)</code>
+                      <code>  (typedef-48.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -191858,7 +191858,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.8" title="local-type: typedef-60.8">local-type: typedef-60.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.8" title="local-type: typedef-48.8">local-type: typedef-48.8</a>
                       </em>
                     </p>
                   </td>
@@ -191870,8 +191870,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.8">
-          <h3>27.73. The complex type <code>complexType[siri:AffectsScopeStructure]/Networks/AffectedNetwork#complexType (typedef-60.8)</code>
+        <div class="sect2" id="local-type.typedef-48.8">
+          <h3>27.73. The complex type <code>complexType[siri:AffectsScopeStructure]/Networks/AffectedNetwork#complexType (typedef-48.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -191891,7 +191891,7 @@
                       <br/>
                       <code>  /Networks/AffectedNetwork #complexType</code>
                       <br/>
-                      <code>  (typedef-60.8)</code>
+                      <code>  (typedef-48.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192486,8 +192486,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.9">
-          <h3>27.74. The complex type <code>complexType[siri:AffectsScopeStructure]/StopPoints#complexType (typedef-60.9)</code>
+        <div class="sect2" id="local-type.typedef-48.9">
+          <h3>27.74. The complex type <code>complexType[siri:AffectsScopeStructure]/StopPoints#complexType (typedef-48.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192507,7 +192507,7 @@
                       <br/>
                       <code>  /StopPoints #complexType</code>
                       <br/>
-                      <code>  (typedef-60.9)</code>
+                      <code>  (typedef-48.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192549,8 +192549,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.10">
-          <h3>27.75. The complex type <code>complexType[siri:AffectsScopeStructure]/StopPlaces#complexType (typedef-60.10)</code>
+        <div class="sect2" id="local-type.typedef-48.10">
+          <h3>27.75. The complex type <code>complexType[siri:AffectsScopeStructure]/StopPlaces#complexType (typedef-48.10)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192570,7 +192570,7 @@
                       <br/>
                       <code>  /StopPlaces #complexType</code>
                       <br/>
-                      <code>  (typedef-60.10)</code>
+                      <code>  (typedef-48.10)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192612,8 +192612,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.11">
-          <h3>27.76. The complex type <code>complexType[siri:AffectsScopeStructure]/Places#complexType (typedef-60.11)</code>
+        <div class="sect2" id="local-type.typedef-48.11">
+          <h3>27.76. The complex type <code>complexType[siri:AffectsScopeStructure]/Places#complexType (typedef-48.11)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192633,7 +192633,7 @@
                       <br/>
                       <code>  /Places #complexType</code>
                       <br/>
-                      <code>  (typedef-60.11)</code>
+                      <code>  (typedef-48.11)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192675,8 +192675,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.12">
-          <h3>27.77. The complex type <code>complexType[siri:AffectsScopeStructure]/VehicleJourneys#complexType (typedef-60.12)</code>
+        <div class="sect2" id="local-type.typedef-48.12">
+          <h3>27.77. The complex type <code>complexType[siri:AffectsScopeStructure]/VehicleJourneys#complexType (typedef-48.12)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192696,7 +192696,7 @@
                       <br/>
                       <code>  /VehicleJourneys #complexType</code>
                       <br/>
-                      <code>  (typedef-60.12)</code>
+                      <code>  (typedef-48.12)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192738,8 +192738,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.13">
-          <h3>27.78. The complex type <code>complexType[siri:AffectsScopeStructure]/Vehicles#complexType (typedef-60.13)</code>
+        <div class="sect2" id="local-type.typedef-48.13">
+          <h3>27.78. The complex type <code>complexType[siri:AffectsScopeStructure]/Vehicles#complexType (typedef-48.13)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192759,7 +192759,7 @@
                       <br/>
                       <code>  /Vehicles #complexType</code>
                       <br/>
-                      <code>  (typedef-60.13)</code>
+                      <code>  (typedef-48.13)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192801,8 +192801,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.17">
-          <h3>27.79. The complex type <code>complexType[siri:PtConsequenceStructure]/Suitabilities#complexType (typedef-60.17)</code>
+        <div class="sect2" id="local-type.typedef-48.17">
+          <h3>27.79. The complex type <code>complexType[siri:PtConsequenceStructure]/Suitabilities#complexType (typedef-48.17)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192822,7 +192822,7 @@
                       <br/>
                       <code>  /Suitabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-60.17)</code>
+                      <code>  (typedef-48.17)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192864,8 +192864,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.2">
-          <h3>27.80. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-60.2)</code>
+        <div class="sect2" id="local-type.typedef-48.2">
+          <h3>27.80. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-48.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192885,7 +192885,7 @@
                       <br/>
                       <code>  /Repetitions #complexType</code>
                       <br/>
-                      <code>  (typedef-60.2)</code>
+                      <code>  (typedef-48.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192929,8 +192929,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.4">
-          <h3>27.81. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-60.4)</code>
+        <div class="sect2" id="local-type.typedef-48.4">
+          <h3>27.81. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-48.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -192950,7 +192950,7 @@
                       <br/>
                       <code>  /SecondaryReasons #complexType</code>
                       <br/>
-                      <code>  (typedef-60.4)</code>
+                      <code>  (typedef-48.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -192980,7 +192980,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.5" title="local-type: typedef-60.5">local-type: typedef-60.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.5" title="local-type: typedef-48.5">local-type: typedef-48.5</a>
                       </em>
                     </p>
                   </td>
@@ -192992,8 +192992,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.5">
-          <h3>27.82. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-60.5)</code>
+        <div class="sect2" id="local-type.typedef-48.5">
+          <h3>27.82. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-48.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193013,7 +193013,7 @@
                       <br/>
                       <code>  /SecondaryReasons/Reason #complexType</code>
                       <br/>
-                      <code>  (typedef-60.5)</code>
+                      <code>  (typedef-48.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -193442,8 +193442,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.14">
-          <h3>27.83. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-60.14)</code>
+        <div class="sect2" id="local-type.typedef-48.14">
+          <h3>27.83. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-48.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193463,7 +193463,7 @@
                       <br/>
                       <code>  /Images #complexType</code>
                       <br/>
-                      <code>  (typedef-60.14)</code>
+                      <code>  (typedef-48.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -193493,7 +193493,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.15" title="local-type: typedef-60.15">local-type: typedef-60.15</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.15" title="local-type: typedef-48.15">local-type: typedef-48.15</a>
                       </em>
                     </p>
                   </td>
@@ -193505,8 +193505,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.15">
-          <h3>27.84. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-60.15)</code>
+        <div class="sect2" id="local-type.typedef-48.15">
+          <h3>27.84. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-48.15)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193526,7 +193526,7 @@
                       <br/>
                       <code>  /Images/Image #complexType</code>
                       <br/>
-                      <code>  (typedef-60.15)</code>
+                      <code>  (typedef-48.15)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -193641,8 +193641,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.16">
-          <h3>27.85. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-60.16)</code>
+        <div class="sect2" id="local-type.typedef-48.16">
+          <h3>27.85. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-48.16)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193662,7 +193662,7 @@
                       <br/>
                       <code>  /InfoLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-60.16)</code>
+                      <code>  (typedef-48.16)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -193704,8 +193704,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.2">
-          <h3>27.86. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-60.2)</code>
+        <div class="sect2" id="local-type.typedef-48.2">
+          <h3>27.86. The complex type <code>group[siri:TemporalGroup]/Repetitions#complexType (typedef-48.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193725,7 +193725,7 @@
                       <br/>
                       <code>  /Repetitions #complexType</code>
                       <br/>
-                      <code>  (typedef-60.2)</code>
+                      <code>  (typedef-48.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -193769,8 +193769,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.4">
-          <h3>27.87. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-60.4)</code>
+        <div class="sect2" id="local-type.typedef-48.4">
+          <h3>27.87. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons#complexType (typedef-48.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193790,7 +193790,7 @@
                       <br/>
                       <code>  /SecondaryReasons #complexType</code>
                       <br/>
-                      <code>  (typedef-60.4)</code>
+                      <code>  (typedef-48.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -193820,7 +193820,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.5" title="local-type: typedef-60.5">local-type: typedef-60.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.5" title="local-type: typedef-48.5">local-type: typedef-48.5</a>
                       </em>
                     </p>
                   </td>
@@ -193832,8 +193832,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.5">
-          <h3>27.88. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-60.5)</code>
+        <div class="sect2" id="local-type.typedef-48.5">
+          <h3>27.88. The complex type <code>group[siri:ClassifierGroup]/SecondaryReasons/Reason#complexType (typedef-48.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -193853,7 +193853,7 @@
                       <br/>
                       <code>  /SecondaryReasons/Reason #complexType</code>
                       <br/>
-                      <code>  (typedef-60.5)</code>
+                      <code>  (typedef-48.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -194282,8 +194282,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.14">
-          <h3>27.89. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-60.14)</code>
+        <div class="sect2" id="local-type.typedef-48.14">
+          <h3>27.89. The complex type <code>group[siri:DescriptionGroup]/Images#complexType (typedef-48.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -194303,7 +194303,7 @@
                       <br/>
                       <code>  /Images #complexType</code>
                       <br/>
-                      <code>  (typedef-60.14)</code>
+                      <code>  (typedef-48.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -194333,7 +194333,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-60.15" title="local-type: typedef-60.15">local-type: typedef-60.15</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-48.15" title="local-type: typedef-48.15">local-type: typedef-48.15</a>
                       </em>
                     </p>
                   </td>
@@ -194345,8 +194345,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.15">
-          <h3>27.90. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-60.15)</code>
+        <div class="sect2" id="local-type.typedef-48.15">
+          <h3>27.90. The complex type <code>group[siri:DescriptionGroup]/Images/Image#complexType (typedef-48.15)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -194366,7 +194366,7 @@
                       <br/>
                       <code>  /Images/Image #complexType</code>
                       <br/>
-                      <code>  (typedef-60.15)</code>
+                      <code>  (typedef-48.15)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -194481,8 +194481,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-60.16">
-          <h3>27.91. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-60.16)</code>
+        <div class="sect2" id="local-type.typedef-48.16">
+          <h3>27.91. The complex type <code>group[siri:DescriptionGroup]/InfoLinks#complexType (typedef-48.16)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -194502,7 +194502,7 @@
                       <br/>
                       <code>  /InfoLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-60.16)</code>
+                      <code>  (typedef-48.16)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -195286,7 +195286,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.3" title="local-type: typedef-54.3">local-type: typedef-54.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.3" title="local-type: typedef-36.3">local-type: typedef-36.3</a>
                       </em>
                     </p>
                   </td>
@@ -195534,7 +195534,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.2" title="local-type: typedef-54.2">local-type: typedef-54.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.2" title="local-type: typedef-36.2">local-type: typedef-36.2</a>
                       </em>
                     </p>
                   </td>
@@ -195700,7 +195700,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.3" title="local-type: typedef-54.3">local-type: typedef-54.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.3" title="local-type: typedef-36.3">local-type: typedef-36.3</a>
                       </em>
                     </p>
                   </td>
@@ -196352,7 +196352,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.1" title="local-type: typedef-54.1">local-type: typedef-54.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
                       </em>
                     </p>
                   </td>
@@ -196564,7 +196564,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.1" title="local-type: typedef-54.1">local-type: typedef-54.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
                       </em>
                     </p>
                   </td>
@@ -196797,7 +196797,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.1" title="local-type: typedef-54.1">local-type: typedef-54.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
                       </em>
                     </p>
                   </td>
@@ -197032,7 +197032,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.1" title="local-type: typedef-54.1">local-type: typedef-54.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
                       </em>
                     </p>
                   </td>
@@ -197698,7 +197698,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.4" title="local-type: typedef-54.4">local-type: typedef-54.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.4" title="local-type: typedef-36.4">local-type: typedef-36.4</a>
                       </em>
                     </p>
                   </td>
@@ -197886,7 +197886,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.1" title="local-type: typedef-54.1">local-type: typedef-54.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
                       </em>
                     </p>
                   </td>
@@ -198914,7 +198914,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.1" title="local-type: typedef-54.1">local-type: typedef-54.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
                       </em>
                     </p>
                   </td>
@@ -199464,7 +199464,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-54.3" title="local-type: typedef-54.3">local-type: typedef-54.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-36.3" title="local-type: typedef-36.3">local-type: typedef-36.3</a>
                       </em>
                     </p>
                   </td>
@@ -199808,8 +199808,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.3">
-          <h3>28.41. The complex type <code>element[siri:ManualAction]#complexType (typedef-54.3)</code>
+        <div class="sect2" id="local-type.typedef-36.3">
+          <h3>28.41. The complex type <code>element[siri:ManualAction]#complexType (typedef-36.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -199829,7 +199829,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-54.3)</code>
+                      <code>  (typedef-36.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -199947,8 +199947,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.3">
-          <h3>28.42. The complex type <code>element[siri:ManualAction]#complexType (typedef-54.3)</code>
+        <div class="sect2" id="local-type.typedef-36.3">
+          <h3>28.42. The complex type <code>element[siri:ManualAction]#complexType (typedef-36.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -199968,7 +199968,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-54.3)</code>
+                      <code>  (typedef-36.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -200086,8 +200086,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.2">
-          <h3>28.43. The complex type <code>complexType[siri:ActionDataStructure]/PublishAtScope#complexType (typedef-54.2)</code>
+        <div class="sect2" id="local-type.typedef-36.2">
+          <h3>28.43. The complex type <code>complexType[siri:ActionDataStructure]/PublishAtScope#complexType (typedef-36.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -200107,7 +200107,7 @@
                       <br/>
                       <code>  /PublishAtScope #complexType</code>
                       <br/>
-                      <code>  (typedef-54.2)</code>
+                      <code>  (typedef-36.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -200174,8 +200174,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.3">
-          <h3>28.44. The complex type <code>element[siri:ManualAction]#complexType (typedef-54.3)</code>
+        <div class="sect2" id="local-type.typedef-36.3">
+          <h3>28.44. The complex type <code>element[siri:ManualAction]#complexType (typedef-36.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -200195,7 +200195,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-54.3)</code>
+                      <code>  (typedef-36.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -200313,8 +200313,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.1">
-          <h3>28.45. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-54.1)</code>
+        <div class="sect2" id="local-type.typedef-36.1">
+          <h3>28.45. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-36.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -200334,7 +200334,7 @@
                       <br/>
                       <code>  /BeforeNotices #complexType</code>
                       <br/>
-                      <code>  (typedef-54.1)</code>
+                      <code>  (typedef-36.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -200373,8 +200373,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.1">
-          <h3>28.46. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-54.1)</code>
+        <div class="sect2" id="local-type.typedef-36.1">
+          <h3>28.46. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-36.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -200394,7 +200394,7 @@
                       <br/>
                       <code>  /BeforeNotices #complexType</code>
                       <br/>
-                      <code>  (typedef-54.1)</code>
+                      <code>  (typedef-36.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -200433,8 +200433,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.1">
-          <h3>28.47. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-54.1)</code>
+        <div class="sect2" id="local-type.typedef-36.1">
+          <h3>28.47. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-36.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -200454,7 +200454,7 @@
                       <br/>
                       <code>  /BeforeNotices #complexType</code>
                       <br/>
-                      <code>  (typedef-54.1)</code>
+                      <code>  (typedef-36.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -200493,8 +200493,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.1">
-          <h3>28.48. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-54.1)</code>
+        <div class="sect2" id="local-type.typedef-36.1">
+          <h3>28.48. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-36.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -200514,7 +200514,7 @@
                       <br/>
                       <code>  /BeforeNotices #complexType</code>
                       <br/>
-                      <code>  (typedef-54.1)</code>
+                      <code>  (typedef-36.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -200553,8 +200553,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.4">
-          <h3>28.49. The complex type <code>complexType[siri:PublishingActionStructure]/PublishAtScope#complexType (typedef-54.4)</code>
+        <div class="sect2" id="local-type.typedef-36.4">
+          <h3>28.49. The complex type <code>complexType[siri:PublishingActionStructure]/PublishAtScope#complexType (typedef-36.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -200574,7 +200574,7 @@
                       <br/>
                       <code>  /PublishAtScope #complexType</code>
                       <br/>
-                      <code>  (typedef-54.4)</code>
+                      <code>  (typedef-36.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -200641,8 +200641,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.1">
-          <h3>28.50. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-54.1)</code>
+        <div class="sect2" id="local-type.typedef-36.1">
+          <h3>28.50. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-36.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -200662,7 +200662,7 @@
                       <br/>
                       <code>  /BeforeNotices #complexType</code>
                       <br/>
-                      <code>  (typedef-54.1)</code>
+                      <code>  (typedef-36.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -200701,8 +200701,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.1">
-          <h3>28.51. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-54.1)</code>
+        <div class="sect2" id="local-type.typedef-36.1">
+          <h3>28.51. The complex type <code>complexType[siri:PushedActionStructure]/BeforeNotices#complexType (typedef-36.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -200722,7 +200722,7 @@
                       <br/>
                       <code>  /BeforeNotices #complexType</code>
                       <br/>
-                      <code>  (typedef-54.1)</code>
+                      <code>  (typedef-36.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -200761,8 +200761,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-54.3">
-          <h3>28.52. The complex type <code>element[siri:ManualAction]#complexType (typedef-54.3)</code>
+        <div class="sect2" id="local-type.typedef-36.3">
+          <h3>28.52. The complex type <code>element[siri:ManualAction]#complexType (typedef-36.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -200782,7 +200782,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-54.3)</code>
+                      <code>  (typedef-36.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -202651,7 +202651,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.1" title="local-type: typedef-64.1">local-type: typedef-64.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.1" title="local-type: typedef-52.1">local-type: typedef-52.1</a>
                       </em>
                     </p>
                   </td>
@@ -202675,7 +202675,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.2" title="local-type: typedef-64.2">local-type: typedef-64.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.2" title="local-type: typedef-52.2">local-type: typedef-52.2</a>
                       </em>
                     </p>
                   </td>
@@ -203281,7 +203281,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.16" title="local-type: typedef-64.16">local-type: typedef-64.16</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.16" title="local-type: typedef-52.16">local-type: typedef-52.16</a>
                       </em>
                     </p>
                   </td>
@@ -204239,7 +204239,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.4" title="local-type: typedef-64.4">local-type: typedef-64.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.4" title="local-type: typedef-52.4">local-type: typedef-52.4</a>
                       </em>
                     </p>
                   </td>
@@ -204263,7 +204263,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.5" title="local-type: typedef-64.5">local-type: typedef-64.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.5" title="local-type: typedef-52.5">local-type: typedef-52.5</a>
                       </em>
                     </p>
                   </td>
@@ -204287,7 +204287,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.6" title="local-type: typedef-64.6">local-type: typedef-64.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.6" title="local-type: typedef-52.6">local-type: typedef-52.6</a>
                       </em>
                     </p>
                   </td>
@@ -204311,7 +204311,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.7" title="local-type: typedef-64.7">local-type: typedef-64.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.7" title="local-type: typedef-52.7">local-type: typedef-52.7</a>
                       </em>
                     </p>
                   </td>
@@ -204537,7 +204537,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.3" title="local-type: typedef-64.3">local-type: typedef-64.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.3" title="local-type: typedef-52.3">local-type: typedef-52.3</a>
                       </em>
                     </p>
                   </td>
@@ -205813,7 +205813,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.9" title="local-type: typedef-64.9">local-type: typedef-64.9</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.9" title="local-type: typedef-52.9">local-type: typedef-52.9</a>
                       </em>
                     </p>
                   </td>
@@ -205837,7 +205837,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.10" title="local-type: typedef-64.10">local-type: typedef-64.10</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.10" title="local-type: typedef-52.10">local-type: typedef-52.10</a>
                       </em>
                     </p>
                   </td>
@@ -205861,7 +205861,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.11" title="local-type: typedef-64.11">local-type: typedef-64.11</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.11" title="local-type: typedef-52.11">local-type: typedef-52.11</a>
                       </em>
                     </p>
                   </td>
@@ -205984,7 +205984,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.8" title="local-type: typedef-64.8">local-type: typedef-64.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.8" title="local-type: typedef-52.8">local-type: typedef-52.8</a>
                       </em>
                     </p>
                   </td>
@@ -206340,7 +206340,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.21" title="local-type: typedef-64.21">local-type: typedef-64.21</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.21" title="local-type: typedef-52.21">local-type: typedef-52.21</a>
                       </em>
                     </p>
                   </td>
@@ -206583,7 +206583,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.18" title="local-type: typedef-64.18">local-type: typedef-64.18</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.18" title="local-type: typedef-52.18">local-type: typedef-52.18</a>
                       </em>
                     </p>
                   </td>
@@ -206607,7 +206607,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.19" title="local-type: typedef-64.19">local-type: typedef-64.19</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.19" title="local-type: typedef-52.19">local-type: typedef-52.19</a>
                       </em>
                     </p>
                   </td>
@@ -206631,7 +206631,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.20" title="local-type: typedef-64.20">local-type: typedef-64.20</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.20" title="local-type: typedef-52.20">local-type: typedef-52.20</a>
                       </em>
                     </p>
                   </td>
@@ -206660,7 +206660,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.17" title="local-type: typedef-64.17">local-type: typedef-64.17</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.17" title="local-type: typedef-52.17">local-type: typedef-52.17</a>
                       </em>
                     </p>
                   </td>
@@ -206853,7 +206853,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.18" title="local-type: typedef-64.18">local-type: typedef-64.18</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.18" title="local-type: typedef-52.18">local-type: typedef-52.18</a>
                       </em>
                     </p>
                   </td>
@@ -206877,7 +206877,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.19" title="local-type: typedef-64.19">local-type: typedef-64.19</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.19" title="local-type: typedef-52.19">local-type: typedef-52.19</a>
                       </em>
                     </p>
                   </td>
@@ -206901,7 +206901,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.20" title="local-type: typedef-64.20">local-type: typedef-64.20</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.20" title="local-type: typedef-52.20">local-type: typedef-52.20</a>
                       </em>
                     </p>
                   </td>
@@ -207253,7 +207253,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.1" title="local-type: typedef-64.1">local-type: typedef-64.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.1" title="local-type: typedef-52.1">local-type: typedef-52.1</a>
                       </em>
                     </p>
                   </td>
@@ -207282,7 +207282,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.2" title="local-type: typedef-64.2">local-type: typedef-64.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.2" title="local-type: typedef-52.2">local-type: typedef-52.2</a>
                       </em>
                     </p>
                   </td>
@@ -207652,7 +207652,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.1" title="local-type: typedef-64.1">local-type: typedef-64.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.1" title="local-type: typedef-52.1">local-type: typedef-52.1</a>
                       </em>
                     </p>
                   </td>
@@ -207947,7 +207947,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.12" title="local-type: typedef-64.12">local-type: typedef-64.12</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.12" title="local-type: typedef-52.12">local-type: typedef-52.12</a>
                       </em>
                     </p>
                   </td>
@@ -207971,7 +207971,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.13" title="local-type: typedef-64.13">local-type: typedef-64.13</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.13" title="local-type: typedef-52.13">local-type: typedef-52.13</a>
                       </em>
                     </p>
                   </td>
@@ -208113,7 +208113,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -208137,7 +208137,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -208210,7 +208210,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.14" title="local-type: typedef-64.14">local-type: typedef-64.14</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.14" title="local-type: typedef-52.14">local-type: typedef-52.14</a>
                       </em>
                     </p>
                   </td>
@@ -208234,7 +208234,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-64.15" title="local-type: typedef-64.15">local-type: typedef-64.15</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-52.15" title="local-type: typedef-52.15">local-type: typedef-52.15</a>
                       </em>
                     </p>
                   </td>
@@ -209454,8 +209454,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.1">
-          <h3>29.44. The complex type <code>complexType[siri:AffectedStopPointWithoutLineStructure]/ConnectionLinks#complexType (typedef-64.1)</code>
+        <div class="sect2" id="local-type.typedef-52.1">
+          <h3>29.44. The complex type <code>complexType[siri:AffectedStopPointWithoutLineStructure]/ConnectionLinks#complexType (typedef-52.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -209475,7 +209475,7 @@
                       <br/>
                       <code>  /ConnectionLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-64.1)</code>
+                      <code>  (typedef-52.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -209517,8 +209517,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.2">
-          <h3>29.45. The complex type <code>complexType[siri:AffectedStopPointStructure]/Lines#complexType (typedef-64.2)</code>
+        <div class="sect2" id="local-type.typedef-52.2">
+          <h3>29.45. The complex type <code>complexType[siri:AffectedStopPointStructure]/Lines#complexType (typedef-52.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -209538,7 +209538,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-64.2)</code>
+                      <code>  (typedef-52.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -209580,8 +209580,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.16">
-          <h3>29.46. The complex type <code>complexType[siri:AffectedCallStructure]/AffectedInterchanges#complexType (typedef-64.16)</code>
+        <div class="sect2" id="local-type.typedef-52.16">
+          <h3>29.46. The complex type <code>complexType[siri:AffectedCallStructure]/AffectedInterchanges#complexType (typedef-52.16)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -209601,7 +209601,7 @@
                       <br/>
                       <code>  /AffectedInterchanges #complexType</code>
                       <br/>
-                      <code>  (typedef-64.16)</code>
+                      <code>  (typedef-52.16)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -209639,8 +209639,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.4">
-          <h3>29.47. The complex type <code>complexType[siri:AffectedLineStructure]/Routes#complexType (typedef-64.4)</code>
+        <div class="sect2" id="local-type.typedef-52.4">
+          <h3>29.47. The complex type <code>complexType[siri:AffectedLineStructure]/Routes#complexType (typedef-52.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -209660,7 +209660,7 @@
                       <br/>
                       <code>  /Routes #complexType</code>
                       <br/>
-                      <code>  (typedef-64.4)</code>
+                      <code>  (typedef-52.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -209702,8 +209702,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.5">
-          <h3>29.48. The complex type <code>complexType[siri:AffectedLineStructure]/Sections#complexType (typedef-64.5)</code>
+        <div class="sect2" id="local-type.typedef-52.5">
+          <h3>29.48. The complex type <code>complexType[siri:AffectedLineStructure]/Sections#complexType (typedef-52.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -209723,7 +209723,7 @@
                       <br/>
                       <code>  /Sections #complexType</code>
                       <br/>
-                      <code>  (typedef-64.5)</code>
+                      <code>  (typedef-52.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -209765,8 +209765,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.6">
-          <h3>29.49. The complex type <code>complexType[siri:AffectedLineStructure]/StopPoints#complexType (typedef-64.6)</code>
+        <div class="sect2" id="local-type.typedef-52.6">
+          <h3>29.49. The complex type <code>complexType[siri:AffectedLineStructure]/StopPoints#complexType (typedef-52.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -209786,7 +209786,7 @@
                       <br/>
                       <code>  /StopPoints #complexType</code>
                       <br/>
-                      <code>  (typedef-64.6)</code>
+                      <code>  (typedef-52.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -209828,8 +209828,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.7">
-          <h3>29.50. The complex type <code>complexType[siri:AffectedLineStructure]/StopPlaces#complexType (typedef-64.7)</code>
+        <div class="sect2" id="local-type.typedef-52.7">
+          <h3>29.50. The complex type <code>complexType[siri:AffectedLineStructure]/StopPlaces#complexType (typedef-52.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -209849,7 +209849,7 @@
                       <br/>
                       <code>  /StopPlaces #complexType</code>
                       <br/>
-                      <code>  (typedef-64.7)</code>
+                      <code>  (typedef-52.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -209891,8 +209891,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.3">
-          <h3>29.51. The complex type <code>complexType[siri:AffectedModesStructure]/Mode#complexType (typedef-64.3)</code>
+        <div class="sect2" id="local-type.typedef-52.3">
+          <h3>29.51. The complex type <code>complexType[siri:AffectedModesStructure]/Mode#complexType (typedef-52.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -209912,7 +209912,7 @@
                       <br/>
                       <code>  /Mode #complexType</code>
                       <br/>
-                      <code>  (typedef-64.3)</code>
+                      <code>  (typedef-52.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -210241,8 +210241,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.9">
-          <h3>29.52. The complex type <code>complexType[siri:AffectedRouteStructure]/Sections#complexType (typedef-64.9)</code>
+        <div class="sect2" id="local-type.typedef-52.9">
+          <h3>29.52. The complex type <code>complexType[siri:AffectedRouteStructure]/Sections#complexType (typedef-52.9)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -210262,7 +210262,7 @@
                       <br/>
                       <code>  /Sections #complexType</code>
                       <br/>
-                      <code>  (typedef-64.9)</code>
+                      <code>  (typedef-52.9)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -210304,8 +210304,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.10">
-          <h3>29.53. The complex type <code>complexType[siri:AffectedRouteStructure]/StopPoints#complexType (typedef-64.10)</code>
+        <div class="sect2" id="local-type.typedef-52.10">
+          <h3>29.53. The complex type <code>complexType[siri:AffectedRouteStructure]/StopPoints#complexType (typedef-52.10)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -210325,7 +210325,7 @@
                       <br/>
                       <code>  /StopPoints #complexType</code>
                       <br/>
-                      <code>  (typedef-64.10)</code>
+                      <code>  (typedef-52.10)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -210414,8 +210414,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.11">
-          <h3>29.54. The complex type <code>complexType[siri:AffectedRouteStructure]/RouteLinks#complexType (typedef-64.11)</code>
+        <div class="sect2" id="local-type.typedef-52.11">
+          <h3>29.54. The complex type <code>complexType[siri:AffectedRouteStructure]/RouteLinks#complexType (typedef-52.11)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -210435,7 +210435,7 @@
                       <br/>
                       <code>  /RouteLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-64.11)</code>
+                      <code>  (typedef-52.11)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -210477,8 +210477,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.8">
-          <h3>29.55. The complex type <code>complexType[siri:AffectedSectionStructure]/IndirectSectionRef#complexType (typedef-64.8)</code>
+        <div class="sect2" id="local-type.typedef-52.8">
+          <h3>29.55. The complex type <code>complexType[siri:AffectedSectionStructure]/IndirectSectionRef#complexType (typedef-52.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -210498,7 +210498,7 @@
                       <br/>
                       <code>  /IndirectSectionRef #complexType</code>
                       <br/>
-                      <code>  (typedef-64.8)</code>
+                      <code>  (typedef-52.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -210824,8 +210824,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.21">
-          <h3>29.56. The complex type <code>complexType[siri:AffectedStopPlaceComponentStructure]/AffectedFacilities#complexType (typedef-64.21)</code>
+        <div class="sect2" id="local-type.typedef-52.21">
+          <h3>29.56. The complex type <code>complexType[siri:AffectedStopPlaceComponentStructure]/AffectedFacilities#complexType (typedef-52.21)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -210845,7 +210845,7 @@
                       <br/>
                       <code>  /AffectedFacilities #complexType</code>
                       <br/>
-                      <code>  (typedef-64.21)</code>
+                      <code>  (typedef-52.21)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -210887,8 +210887,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.18">
-          <h3>29.57. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedFacilities#complexType (typedef-64.18)</code>
+        <div class="sect2" id="local-type.typedef-52.18">
+          <h3>29.57. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedFacilities#complexType (typedef-52.18)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -210908,7 +210908,7 @@
                       <br/>
                       <code>  /AffectedFacilities #complexType</code>
                       <br/>
-                      <code>  (typedef-64.18)</code>
+                      <code>  (typedef-52.18)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -210950,8 +210950,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.19">
-          <h3>29.58. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedComponents#complexType (typedef-64.19)</code>
+        <div class="sect2" id="local-type.typedef-52.19">
+          <h3>29.58. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedComponents#complexType (typedef-52.19)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -210971,7 +210971,7 @@
                       <br/>
                       <code>  /AffectedComponents #complexType</code>
                       <br/>
-                      <code>  (typedef-64.19)</code>
+                      <code>  (typedef-52.19)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -211009,8 +211009,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.20">
-          <h3>29.59. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedNavigationPaths#complexType (typedef-64.20)</code>
+        <div class="sect2" id="local-type.typedef-52.20">
+          <h3>29.59. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedNavigationPaths#complexType (typedef-52.20)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -211030,7 +211030,7 @@
                       <br/>
                       <code>  /AffectedNavigationPaths #complexType</code>
                       <br/>
-                      <code>  (typedef-64.20)</code>
+                      <code>  (typedef-52.20)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -211072,8 +211072,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.17">
-          <h3>29.60. The complex type <code>complexType[siri:AffectedStopPlaceStructure]/Lines#complexType (typedef-64.17)</code>
+        <div class="sect2" id="local-type.typedef-52.17">
+          <h3>29.60. The complex type <code>complexType[siri:AffectedStopPlaceStructure]/Lines#complexType (typedef-52.17)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -211093,7 +211093,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-64.17)</code>
+                      <code>  (typedef-52.17)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -211135,8 +211135,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.18">
-          <h3>29.61. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedFacilities#complexType (typedef-64.18)</code>
+        <div class="sect2" id="local-type.typedef-52.18">
+          <h3>29.61. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedFacilities#complexType (typedef-52.18)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -211156,7 +211156,7 @@
                       <br/>
                       <code>  /AffectedFacilities #complexType</code>
                       <br/>
-                      <code>  (typedef-64.18)</code>
+                      <code>  (typedef-52.18)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -211198,8 +211198,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.19">
-          <h3>29.62. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedComponents#complexType (typedef-64.19)</code>
+        <div class="sect2" id="local-type.typedef-52.19">
+          <h3>29.62. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedComponents#complexType (typedef-52.19)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -211219,7 +211219,7 @@
                       <br/>
                       <code>  /AffectedComponents #complexType</code>
                       <br/>
-                      <code>  (typedef-64.19)</code>
+                      <code>  (typedef-52.19)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -211257,8 +211257,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.20">
-          <h3>29.63. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedNavigationPaths#complexType (typedef-64.20)</code>
+        <div class="sect2" id="local-type.typedef-52.20">
+          <h3>29.63. The complex type <code>complexType[siri:AffectedStopPlaceWithoutLineStructure]/AffectedNavigationPaths#complexType (typedef-52.20)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -211278,7 +211278,7 @@
                       <br/>
                       <code>  /AffectedNavigationPaths #complexType</code>
                       <br/>
-                      <code>  (typedef-64.20)</code>
+                      <code>  (typedef-52.20)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -211320,8 +211320,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.1">
-          <h3>29.64. The complex type <code>complexType[siri:AffectedStopPointWithoutLineStructure]/ConnectionLinks#complexType (typedef-64.1)</code>
+        <div class="sect2" id="local-type.typedef-52.1">
+          <h3>29.64. The complex type <code>complexType[siri:AffectedStopPointWithoutLineStructure]/ConnectionLinks#complexType (typedef-52.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -211341,7 +211341,7 @@
                       <br/>
                       <code>  /ConnectionLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-64.1)</code>
+                      <code>  (typedef-52.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -211383,8 +211383,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.2">
-          <h3>29.65. The complex type <code>complexType[siri:AffectedStopPointStructure]/Lines#complexType (typedef-64.2)</code>
+        <div class="sect2" id="local-type.typedef-52.2">
+          <h3>29.65. The complex type <code>complexType[siri:AffectedStopPointStructure]/Lines#complexType (typedef-52.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -211404,7 +211404,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-64.2)</code>
+                      <code>  (typedef-52.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -211446,8 +211446,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.1">
-          <h3>29.66. The complex type <code>complexType[siri:AffectedStopPointWithoutLineStructure]/ConnectionLinks#complexType (typedef-64.1)</code>
+        <div class="sect2" id="local-type.typedef-52.1">
+          <h3>29.66. The complex type <code>complexType[siri:AffectedStopPointWithoutLineStructure]/ConnectionLinks#complexType (typedef-52.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -211467,7 +211467,7 @@
                       <br/>
                       <code>  /ConnectionLinks #complexType</code>
                       <br/>
-                      <code>  (typedef-64.1)</code>
+                      <code>  (typedef-52.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -211509,8 +211509,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.12">
-          <h3>29.67. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/TrainNumbers#complexType (typedef-64.12)</code>
+        <div class="sect2" id="local-type.typedef-52.12">
+          <h3>29.67. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/TrainNumbers#complexType (typedef-52.12)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -211530,7 +211530,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-64.12)</code>
+                      <code>  (typedef-52.12)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -211572,8 +211572,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.13">
-          <h3>29.68. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/JourneyParts#complexType (typedef-64.13)</code>
+        <div class="sect2" id="local-type.typedef-52.13">
+          <h3>29.68. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/JourneyParts#complexType (typedef-52.13)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -211593,7 +211593,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-64.13)</code>
+                      <code>  (typedef-52.13)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -211635,8 +211635,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.14">
-          <h3>29.69. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/Calls#complexType (typedef-64.14)</code>
+        <div class="sect2" id="local-type.typedef-52.14">
+          <h3>29.69. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/Calls#complexType (typedef-52.14)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -211656,7 +211656,7 @@
                       <br/>
                       <code>  /Calls #complexType</code>
                       <br/>
-                      <code>  (typedef-64.14)</code>
+                      <code>  (typedef-52.14)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -211698,8 +211698,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-64.15">
-          <h3>29.70. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/Facilities#complexType (typedef-64.15)</code>
+        <div class="sect2" id="local-type.typedef-52.15">
+          <h3>29.70. The complex type <code>complexType[siri:AffectedVehicleJourneyStructure]/Facilities#complexType (typedef-52.15)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -211719,7 +211719,7 @@
                       <br/>
                       <code>  /Facilities #complexType</code>
                       <br/>
-                      <code>  (typedef-64.15)</code>
+                      <code>  (typedef-52.15)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -212376,12 +212376,12 @@
                 </tr>
                 <tr>
                   <td colspan="1" rowspan="2" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-55.2" class="tableblock">
+                    <p id="local-type.typedef-40.2" class="tableblock">
                       <code>element[siri:Predictability]</code>
                       <br/>
                       <code>  #simpleType</code>
                       <br/>
-                      <code>  (typedef-55.2)</code>
+                      <code>  (typedef-40.2)</code>
                     </p>
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
@@ -212426,12 +212426,12 @@
                 </tr>
                 <tr>
                   <td colspan="1" rowspan="2" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-55.1" class="tableblock">
+                    <p id="local-type.typedef-40.1" class="tableblock">
                       <code>element[siri:VerificationStatus]</code>
                       <br/>
                       <code>  #simpleType</code>
                       <br/>
-                      <code>  (typedef-55.1)</code>
+                      <code>  (typedef-40.1)</code>
                     </p>
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
@@ -219284,7 +219284,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -219305,7 +219305,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -219326,7 +219326,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -219411,7 +219411,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -219432,7 +219432,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -222226,7 +222226,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-4.1" title="local-type: typedef-4.1">local-type: typedef-4.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-12.1" title="local-type: typedef-12.1">local-type: typedef-12.1</a>
                       </em>
                     </p>
                   </td>
@@ -222250,7 +222250,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-4.2" title="local-type: typedef-4.2">local-type: typedef-4.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-12.2" title="local-type: typedef-12.2">local-type: typedef-12.2</a>
                       </em>
                     </p>
                   </td>
@@ -222394,7 +222394,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-4.3" title="local-type: typedef-4.3">local-type: typedef-4.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-12.3" title="local-type: typedef-12.3">local-type: typedef-12.3</a>
                       </em>
                     </p>
                   </td>
@@ -222604,7 +222604,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-2.1" title="local-type: typedef-2.1">local-type: typedef-2.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-15.1" title="local-type: typedef-15.1">local-type: typedef-15.1</a>
                       </em>
                     </p>
                   </td>
@@ -222628,7 +222628,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-2.2" title="local-type: typedef-2.2">local-type: typedef-2.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-15.2" title="local-type: typedef-15.2">local-type: typedef-15.2</a>
                       </em>
                     </p>
                   </td>
@@ -222792,8 +222792,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-4.1">
-          <h3>39.7. The complex type <code>complexType[siri:AnnotatedLineStructure]/Destinations#complexType (typedef-4.1)</code>
+        <div class="sect2" id="local-type.typedef-12.1">
+          <h3>39.7. The complex type <code>complexType[siri:AnnotatedLineStructure]/Destinations#complexType (typedef-12.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -222813,7 +222813,7 @@
                       <br/>
                       <code>  /Destinations #complexType</code>
                       <br/>
-                      <code>  (typedef-4.1)</code>
+                      <code>  (typedef-12.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -222856,8 +222856,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-4.2">
-          <h3>39.8. The complex type <code>complexType[siri:AnnotatedLineStructure]/Directions#complexType (typedef-4.2)</code>
+        <div class="sect2" id="local-type.typedef-12.2">
+          <h3>39.8. The complex type <code>complexType[siri:AnnotatedLineStructure]/Directions#complexType (typedef-12.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -222877,7 +222877,7 @@
                       <br/>
                       <code>  /Directions #complexType</code>
                       <br/>
-                      <code>  (typedef-4.2)</code>
+                      <code>  (typedef-12.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -222919,8 +222919,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-4.3">
-          <h3>39.9. The complex type <code>complexType[siri:RouteDirectionStructure]/JourneyPatterns#complexType (typedef-4.3)</code>
+        <div class="sect2" id="local-type.typedef-12.3">
+          <h3>39.9. The complex type <code>complexType[siri:RouteDirectionStructure]/JourneyPatterns#complexType (typedef-12.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -222940,7 +222940,7 @@
                       <br/>
                       <code>  /JourneyPatterns #complexType</code>
                       <br/>
-                      <code>  (typedef-4.3)</code>
+                      <code>  (typedef-12.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -222970,7 +222970,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-4.4" title="local-type: typedef-4.4">local-type: typedef-4.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-12.4" title="local-type: typedef-12.4">local-type: typedef-12.4</a>
                       </em>
                     </p>
                   </td>
@@ -222982,8 +222982,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-4.4">
-          <h3>39.10. The complex type <code>complexType[siri:RouteDirectionStructure]/JourneyPatterns/JourneyPattern#complexType (typedef-4.4)</code>
+        <div class="sect2" id="local-type.typedef-12.4">
+          <h3>39.10. The complex type <code>complexType[siri:RouteDirectionStructure]/JourneyPatterns/JourneyPattern#complexType (typedef-12.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -223003,7 +223003,7 @@
                       <br/>
                       <code>  /JourneyPatterns/JourneyPattern #complexType</code>
                       <br/>
-                      <code>  (typedef-4.4)</code>
+                      <code>  (typedef-12.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -223078,7 +223078,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-4.5" title="local-type: typedef-4.5">local-type: typedef-4.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-12.5" title="local-type: typedef-12.5">local-type: typedef-12.5</a>
                       </em>
                     </p>
                   </td>
@@ -223090,8 +223090,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-4.5">
-          <h3>39.11. The complex type <code>complexType[siri:RouteDirectionStructure]/JourneyPatterns/JourneyPattern/StopsInPattern#complexType (typedef-4.5)</code>
+        <div class="sect2" id="local-type.typedef-12.5">
+          <h3>39.11. The complex type <code>complexType[siri:RouteDirectionStructure]/JourneyPatterns/JourneyPattern/StopsInPattern#complexType (typedef-12.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -223111,7 +223111,7 @@
                       <br/>
                       <code>  /JourneyPatterns/JourneyPattern/StopsInPattern #complexType</code>
                       <br/>
-                      <code>  (typedef-4.5)</code>
+                      <code>  (typedef-12.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -223153,8 +223153,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-2.1">
-          <h3>39.12. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Features#complexType (typedef-2.1)</code>
+        <div class="sect2" id="local-type.typedef-15.1">
+          <h3>39.12. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Features#complexType (typedef-15.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -223174,7 +223174,7 @@
                       <br/>
                       <code>  /Features #complexType</code>
                       <br/>
-                      <code>  (typedef-2.1)</code>
+                      <code>  (typedef-15.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -223260,8 +223260,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-2.2">
-          <h3>39.13. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Lines#complexType (typedef-2.2)</code>
+        <div class="sect2" id="local-type.typedef-15.2">
+          <h3>39.13. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Lines#complexType (typedef-15.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -223281,7 +223281,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-2.2)</code>
+                      <code>  (typedef-15.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -223569,7 +223569,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-2.1" title="local-type: typedef-2.1">local-type: typedef-2.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-15.1" title="local-type: typedef-15.1">local-type: typedef-15.1</a>
                       </em>
                     </p>
                   </td>
@@ -223593,7 +223593,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-2.2" title="local-type: typedef-2.2">local-type: typedef-2.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-15.2" title="local-type: typedef-15.2">local-type: typedef-15.2</a>
                       </em>
                     </p>
                   </td>
@@ -223652,8 +223652,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-2.1">
-          <h3>40.3. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Features#complexType (typedef-2.1)</code>
+        <div class="sect2" id="local-type.typedef-15.1">
+          <h3>40.3. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Features#complexType (typedef-15.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -223673,7 +223673,7 @@
                       <br/>
                       <code>  /Features #complexType</code>
                       <br/>
-                      <code>  (typedef-2.1)</code>
+                      <code>  (typedef-15.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -223759,8 +223759,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-2.2">
-          <h3>40.4. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Lines#complexType (typedef-2.2)</code>
+        <div class="sect2" id="local-type.typedef-15.2">
+          <h3>40.4. The complex type <code>complexType[siri:AnnotatedStopPointStructure]/Lines#complexType (typedef-15.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -223780,7 +223780,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-2.2)</code>
+                      <code>  (typedef-15.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -224904,7 +224904,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.1" title="local-type: typedef-79.1">local-type: typedef-79.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.1" title="local-type: typedef-76.1">local-type: typedef-76.1</a>
                       </em>
                     </p>
                   </td>
@@ -225054,7 +225054,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.2" title="local-type: typedef-79.2">local-type: typedef-79.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.2" title="local-type: typedef-76.2">local-type: typedef-76.2</a>
                       </em>
                     </p>
                   </td>
@@ -225106,7 +225106,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.3" title="local-type: typedef-79.3">local-type: typedef-79.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.3" title="local-type: typedef-76.3">local-type: typedef-76.3</a>
                       </em>
                     </p>
                   </td>
@@ -225715,7 +225715,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -226166,7 +226166,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.7" title="local-type: typedef-79.7">local-type: typedef-79.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.7" title="local-type: typedef-76.7">local-type: typedef-76.7</a>
                       </em>
                     </p>
                   </td>
@@ -227076,7 +227076,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.1" title="local-type: typedef-79.1">local-type: typedef-79.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.1" title="local-type: typedef-76.1">local-type: typedef-76.1</a>
                       </em>
                     </p>
                   </td>
@@ -227407,7 +227407,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.4" title="local-type: typedef-79.4">local-type: typedef-79.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.4" title="local-type: typedef-76.4">local-type: typedef-76.4</a>
                       </em>
                     </p>
                   </td>
@@ -227431,7 +227431,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.5" title="local-type: typedef-79.5">local-type: typedef-79.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.5" title="local-type: typedef-76.5">local-type: typedef-76.5</a>
                       </em>
                     </p>
                   </td>
@@ -227455,7 +227455,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-79.6" title="local-type: typedef-79.6">local-type: typedef-79.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-76.6" title="local-type: typedef-76.6">local-type: typedef-76.6</a>
                       </em>
                     </p>
                   </td>
@@ -227827,8 +227827,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.3">
-          <h3>41.23. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-79.3)</code>
+        <div class="sect2" id="local-type.typedef-76.3">
+          <h3>41.23. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-76.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -227848,7 +227848,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-79.3)</code>
+                      <code>  (typedef-76.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -227998,8 +227998,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.7">
-          <h3>41.24. The complex type <code>element[siri:ProductionTimetablePermissions]#complexType (typedef-79.7)</code>
+        <div class="sect2" id="local-type.typedef-76.7">
+          <h3>41.24. The complex type <code>element[siri:ProductionTimetablePermissions]#complexType (typedef-76.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -228019,7 +228019,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-79.7)</code>
+                      <code>  (typedef-76.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -228094,8 +228094,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.2">
-          <h3>41.25. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-79.2)</code>
+        <div class="sect2" id="local-type.typedef-76.2">
+          <h3>41.25. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-76.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -228115,7 +228115,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-79.2)</code>
+                      <code>  (typedef-76.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -228312,8 +228312,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.1">
-          <h3>41.26. The complex type <code>group[siri:ProductionTimetableTopicGroup]/Lines#complexType (typedef-79.1)</code>
+        <div class="sect2" id="local-type.typedef-76.1">
+          <h3>41.26. The complex type <code>group[siri:ProductionTimetableTopicGroup]/Lines#complexType (typedef-76.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -228333,7 +228333,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-79.1)</code>
+                      <code>  (typedef-76.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -228375,8 +228375,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.2">
-          <h3>41.27. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-79.2)</code>
+        <div class="sect2" id="local-type.typedef-76.2">
+          <h3>41.27. The complex type <code>element[siri:ProductionTimetableSubscriptionRequest]#complexType (typedef-76.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -228396,7 +228396,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-79.2)</code>
+                      <code>  (typedef-76.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -228593,8 +228593,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.3">
-          <h3>41.28. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-79.3)</code>
+        <div class="sect2" id="local-type.typedef-76.3">
+          <h3>41.28. The complex type <code>element[siri:ProductionTimetableCapabilitiesRequest]#complexType (typedef-76.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -228614,7 +228614,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-79.3)</code>
+                      <code>  (typedef-76.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -228764,8 +228764,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.7">
-          <h3>41.29. The complex type <code>element[siri:ProductionTimetablePermissions]#complexType (typedef-79.7)</code>
+        <div class="sect2" id="local-type.typedef-76.7">
+          <h3>41.29. The complex type <code>element[siri:ProductionTimetablePermissions]#complexType (typedef-76.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -228785,7 +228785,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-79.7)</code>
+                      <code>  (typedef-76.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -228860,8 +228860,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.1">
-          <h3>41.30. The complex type <code>group[siri:ProductionTimetableTopicGroup]/Lines#complexType (typedef-79.1)</code>
+        <div class="sect2" id="local-type.typedef-76.1">
+          <h3>41.30. The complex type <code>group[siri:ProductionTimetableTopicGroup]/Lines#complexType (typedef-76.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -228881,7 +228881,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-79.1)</code>
+                      <code>  (typedef-76.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -228923,8 +228923,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.4">
-          <h3>41.31. The complex type <code>complexType[siri:ProductionTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-79.4)</code>
+        <div class="sect2" id="local-type.typedef-76.4">
+          <h3>41.31. The complex type <code>complexType[siri:ProductionTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-76.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -228944,7 +228944,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-79.4)</code>
+                      <code>  (typedef-76.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -229141,8 +229141,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.5">
-          <h3>41.32. The complex type <code>complexType[siri:ProductionTimetableServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-79.5)</code>
+        <div class="sect2" id="local-type.typedef-76.5">
+          <h3>41.32. The complex type <code>complexType[siri:ProductionTimetableServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-76.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -229162,7 +229162,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-79.5)</code>
+                      <code>  (typedef-76.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -229306,8 +229306,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-79.6">
-          <h3>41.33. The complex type <code>complexType[siri:ProductionTimetableServiceCapabilitiesStructure]/SubscriptionPolicy#complexType (typedef-79.6)</code>
+        <div class="sect2" id="local-type.typedef-76.6">
+          <h3>41.33. The complex type <code>complexType[siri:ProductionTimetableServiceCapabilitiesStructure]/SubscriptionPolicy#complexType (typedef-76.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -229327,7 +229327,7 @@
                       <br/>
                       <code>  /SubscriptionPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-79.6)</code>
+                      <code>  (typedef-76.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -230042,7 +230042,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.3" title="local-type: typedef-73.3">local-type: typedef-73.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.3" title="local-type: typedef-74.3">local-type: typedef-74.3</a>
                       </em>
                     </p>
                   </td>
@@ -230908,7 +230908,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.2" title="local-type: typedef-73.2">local-type: typedef-73.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.2" title="local-type: typedef-74.2">local-type: typedef-74.2</a>
                       </em>
                     </p>
                   </td>
@@ -231221,7 +231221,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.1" title="local-type: typedef-73.1">local-type: typedef-73.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.1" title="local-type: typedef-74.1">local-type: typedef-74.1</a>
                       </em>
                     </p>
                   </td>
@@ -231595,7 +231595,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.2" title="local-type: typedef-73.2">local-type: typedef-73.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.2" title="local-type: typedef-74.2">local-type: typedef-74.2</a>
                       </em>
                     </p>
                   </td>
@@ -232760,7 +232760,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.8" title="local-type: typedef-73.8">local-type: typedef-73.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.8" title="local-type: typedef-74.8">local-type: typedef-74.8</a>
                       </em>
                     </p>
                   </td>
@@ -233268,7 +233268,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.3" title="local-type: typedef-73.3">local-type: typedef-73.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.3" title="local-type: typedef-74.3">local-type: typedef-74.3</a>
                       </em>
                     </p>
                   </td>
@@ -234103,7 +234103,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.2" title="local-type: typedef-73.2">local-type: typedef-73.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.2" title="local-type: typedef-74.2">local-type: typedef-74.2</a>
                       </em>
                     </p>
                   </td>
@@ -234416,7 +234416,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.1" title="local-type: typedef-73.1">local-type: typedef-73.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.1" title="local-type: typedef-74.1">local-type: typedef-74.1</a>
                       </em>
                     </p>
                   </td>
@@ -234641,7 +234641,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.4" title="local-type: typedef-73.4">local-type: typedef-73.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.4" title="local-type: typedef-74.4">local-type: typedef-74.4</a>
                       </em>
                     </p>
                   </td>
@@ -234665,7 +234665,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.5" title="local-type: typedef-73.5">local-type: typedef-73.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.5" title="local-type: typedef-74.5">local-type: typedef-74.5</a>
                       </em>
                     </p>
                   </td>
@@ -234713,7 +234713,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.6" title="local-type: typedef-73.6">local-type: typedef-73.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.6" title="local-type: typedef-74.6">local-type: typedef-74.6</a>
                       </em>
                     </p>
                   </td>
@@ -234737,7 +234737,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-73.7" title="local-type: typedef-73.7">local-type: typedef-73.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-74.7" title="local-type: typedef-74.7">local-type: typedef-74.7</a>
                       </em>
                     </p>
                   </td>
@@ -234896,7 +234896,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-69.1" title="local-type: typedef-69.1">local-type: typedef-69.1</a>
                       </em>
                     </p>
                   </td>
@@ -234930,7 +234930,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-56.2" title="local-type: typedef-56.2">local-type: typedef-56.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-33.2" title="local-type: typedef-33.2">local-type: typedef-33.2</a>
                       </em>
                     </p>
                   </td>
@@ -234959,7 +234959,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-56.1" title="local-type: typedef-56.1">local-type: typedef-56.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-33.1" title="local-type: typedef-33.1">local-type: typedef-33.1</a>
                       </em>
                     </p>
                   </td>
@@ -235215,8 +235215,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.8">
-          <h3>42.33. The complex type <code>element[siri:SituationExchangePermissions]#complexType (typedef-73.8)</code>
+        <div class="sect2" id="local-type.typedef-74.8">
+          <h3>42.33. The complex type <code>element[siri:SituationExchangePermissions]#complexType (typedef-74.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -235236,7 +235236,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-73.8)</code>
+                      <code>  (typedef-74.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -235310,8 +235310,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.3">
-          <h3>42.34. The complex type <code>group[siri:SituationExchangePayloadGroup]/Situations#complexType (typedef-73.3)</code>
+        <div class="sect2" id="local-type.typedef-74.3">
+          <h3>42.34. The complex type <code>group[siri:SituationExchangePayloadGroup]/Situations#complexType (typedef-74.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -235331,7 +235331,7 @@
                       <br/>
                       <code>  /Situations #complexType</code>
                       <br/>
-                      <code>  (typedef-73.3)</code>
+                      <code>  (typedef-74.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -235394,8 +235394,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.2">
-          <h3>42.35. The complex type <code>group[siri:SituationNetworkFilterGroup]/Lines#complexType (typedef-73.2)</code>
+        <div class="sect2" id="local-type.typedef-74.2">
+          <h3>42.35. The complex type <code>group[siri:SituationNetworkFilterGroup]/Lines#complexType (typedef-74.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -235415,7 +235415,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-73.2)</code>
+                      <code>  (typedef-74.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -235457,8 +235457,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.1">
-          <h3>42.36. The complex type <code>group[siri:SituationExchangeTopicGroup]/SituationRoadFilter#complexType (typedef-73.1)</code>
+        <div class="sect2" id="local-type.typedef-74.1">
+          <h3>42.36. The complex type <code>group[siri:SituationExchangeTopicGroup]/SituationRoadFilter#complexType (typedef-74.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -235478,7 +235478,7 @@
                       <br/>
                       <code>  /SituationRoadFilter #complexType</code>
                       <br/>
-                      <code>  (typedef-73.1)</code>
+                      <code>  (typedef-74.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -235520,8 +235520,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.2">
-          <h3>42.37. The complex type <code>group[siri:SituationNetworkFilterGroup]/Lines#complexType (typedef-73.2)</code>
+        <div class="sect2" id="local-type.typedef-74.2">
+          <h3>42.37. The complex type <code>group[siri:SituationNetworkFilterGroup]/Lines#complexType (typedef-74.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -235541,7 +235541,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-73.2)</code>
+                      <code>  (typedef-74.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -235583,8 +235583,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.8">
-          <h3>42.38. The complex type <code>element[siri:SituationExchangePermissions]#complexType (typedef-73.8)</code>
+        <div class="sect2" id="local-type.typedef-74.8">
+          <h3>42.38. The complex type <code>element[siri:SituationExchangePermissions]#complexType (typedef-74.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -235604,7 +235604,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-73.8)</code>
+                      <code>  (typedef-74.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -235678,8 +235678,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.3">
-          <h3>42.39. The complex type <code>group[siri:SituationExchangePayloadGroup]/Situations#complexType (typedef-73.3)</code>
+        <div class="sect2" id="local-type.typedef-74.3">
+          <h3>42.39. The complex type <code>group[siri:SituationExchangePayloadGroup]/Situations#complexType (typedef-74.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -235699,7 +235699,7 @@
                       <br/>
                       <code>  /Situations #complexType</code>
                       <br/>
-                      <code>  (typedef-73.3)</code>
+                      <code>  (typedef-74.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -235762,8 +235762,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.2">
-          <h3>42.40. The complex type <code>group[siri:SituationNetworkFilterGroup]/Lines#complexType (typedef-73.2)</code>
+        <div class="sect2" id="local-type.typedef-74.2">
+          <h3>42.40. The complex type <code>group[siri:SituationNetworkFilterGroup]/Lines#complexType (typedef-74.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -235783,7 +235783,7 @@
                       <br/>
                       <code>  /Lines #complexType</code>
                       <br/>
-                      <code>  (typedef-73.2)</code>
+                      <code>  (typedef-74.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -235825,8 +235825,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.1">
-          <h3>42.41. The complex type <code>group[siri:SituationExchangeTopicGroup]/SituationRoadFilter#complexType (typedef-73.1)</code>
+        <div class="sect2" id="local-type.typedef-74.1">
+          <h3>42.41. The complex type <code>group[siri:SituationExchangeTopicGroup]/SituationRoadFilter#complexType (typedef-74.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -235846,7 +235846,7 @@
                       <br/>
                       <code>  /SituationRoadFilter #complexType</code>
                       <br/>
-                      <code>  (typedef-73.1)</code>
+                      <code>  (typedef-74.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -235888,8 +235888,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.4">
-          <h3>42.42. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-73.4)</code>
+        <div class="sect2" id="local-type.typedef-74.4">
+          <h3>42.42. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-74.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -235909,7 +235909,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-73.4)</code>
+                      <code>  (typedef-74.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -236258,8 +236258,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.5">
-          <h3>42.43. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-73.5)</code>
+        <div class="sect2" id="local-type.typedef-74.5">
+          <h3>42.43. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-74.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -236279,7 +236279,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-73.5)</code>
+                      <code>  (typedef-74.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -236451,8 +236451,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.6">
-          <h3>42.44. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/AccessControl#complexType (typedef-73.6)</code>
+        <div class="sect2" id="local-type.typedef-74.6">
+          <h3>42.44. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/AccessControl#complexType (typedef-74.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -236472,7 +236472,7 @@
                       <br/>
                       <code>  /AccessControl #complexType</code>
                       <br/>
-                      <code>  (typedef-73.6)</code>
+                      <code>  (typedef-74.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -236573,8 +236573,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-73.7">
-          <h3>42.45. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-73.7)</code>
+        <div class="sect2" id="local-type.typedef-74.7">
+          <h3>42.45. The complex type <code>complexType[siri:SituationExchangeServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-74.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -236594,7 +236594,7 @@
                       <br/>
                       <code>  /ResponseFeatures #complexType</code>
                       <br/>
-                      <code>  (typedef-73.7)</code>
+                      <code>  (typedef-74.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -236608,8 +236608,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-36.1">
-          <h3>42.46. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-36.1)</code>
+        <div class="sect2" id="local-type.typedef-69.1">
+          <h3>42.46. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-69.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -236629,7 +236629,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-36.1)</code>
+                      <code>  (typedef-69.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -236697,8 +236697,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-56.2">
-          <h3>42.47. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-56.2)</code>
+        <div class="sect2" id="local-type.typedef-33.2">
+          <h3>42.47. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-33.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -236718,7 +236718,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-56.2)</code>
+                      <code>  (typedef-33.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -236803,8 +236803,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-56.1">
-          <h3>42.48. The complex type <code>element[siri:LinePermissions]#complexType (typedef-56.1)</code>
+        <div class="sect2" id="local-type.typedef-33.1">
+          <h3>42.48. The complex type <code>element[siri:LinePermissions]#complexType (typedef-33.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -236824,7 +236824,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-56.1)</code>
+                      <code>  (typedef-33.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -238359,7 +238359,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-81.1" title="local-type: typedef-81.1">local-type: typedef-81.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.1" title="local-type: typedef-73.1">local-type: typedef-73.1</a>
                       </em>
                     </p>
                   </td>
@@ -240912,7 +240912,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-81.5" title="local-type: typedef-81.5">local-type: typedef-81.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.5" title="local-type: typedef-73.5">local-type: typedef-73.5</a>
                       </em>
                     </p>
                   </td>
@@ -242244,7 +242244,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-81.1" title="local-type: typedef-81.1">local-type: typedef-81.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.1" title="local-type: typedef-73.1">local-type: typedef-73.1</a>
                       </em>
                     </p>
                   </td>
@@ -242923,7 +242923,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-81.1" title="local-type: typedef-81.1">local-type: typedef-81.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.1" title="local-type: typedef-73.1">local-type: typedef-73.1</a>
                       </em>
                     </p>
                   </td>
@@ -243063,7 +243063,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-81.2" title="local-type: typedef-81.2">local-type: typedef-81.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.2" title="local-type: typedef-73.2">local-type: typedef-73.2</a>
                       </em>
                     </p>
                   </td>
@@ -243087,7 +243087,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-81.3" title="local-type: typedef-81.3">local-type: typedef-81.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.3" title="local-type: typedef-73.3">local-type: typedef-73.3</a>
                       </em>
                     </p>
                   </td>
@@ -243159,7 +243159,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-81.4" title="local-type: typedef-81.4">local-type: typedef-81.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.4" title="local-type: typedef-73.4">local-type: typedef-73.4</a>
                       </em>
                     </p>
                   </td>
@@ -243293,7 +243293,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-69.1" title="local-type: typedef-69.1">local-type: typedef-69.1</a>
                       </em>
                     </p>
                   </td>
@@ -243327,7 +243327,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-56.2" title="local-type: typedef-56.2">local-type: typedef-56.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-33.2" title="local-type: typedef-33.2">local-type: typedef-33.2</a>
                       </em>
                     </p>
                   </td>
@@ -243356,7 +243356,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-56.1" title="local-type: typedef-56.1">local-type: typedef-56.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-33.1" title="local-type: typedef-33.1">local-type: typedef-33.1</a>
                       </em>
                     </p>
                   </td>
@@ -243384,7 +243384,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-81.6" title="local-type: typedef-81.6">local-type: typedef-81.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-73.6" title="local-type: typedef-73.6">local-type: typedef-73.6</a>
                       </em>
                     </p>
                   </td>
@@ -244087,8 +244087,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-81.5">
-          <h3>43.47. The complex type <code>element[siri:StopMonitoringPermissions]#complexType (typedef-81.5)</code>
+        <div class="sect2" id="local-type.typedef-73.5">
+          <h3>43.47. The complex type <code>element[siri:StopMonitoringPermissions]#complexType (typedef-73.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -244108,7 +244108,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-81.5)</code>
+                      <code>  (typedef-73.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -244182,8 +244182,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-81.1">
-          <h3>43.48. The complex type <code>group[siri:StopMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-81.1)</code>
+        <div class="sect2" id="local-type.typedef-73.1">
+          <h3>43.48. The complex type <code>group[siri:StopMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-73.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -244203,7 +244203,7 @@
                       <br/>
                       <code>  /MaximumNumberOfCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-81.1)</code>
+                      <code>  (typedef-73.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -244263,8 +244263,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-81.5">
-          <h3>43.49. The complex type <code>element[siri:StopMonitoringPermissions]#complexType (typedef-81.5)</code>
+        <div class="sect2" id="local-type.typedef-73.5">
+          <h3>43.49. The complex type <code>element[siri:StopMonitoringPermissions]#complexType (typedef-73.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -244284,7 +244284,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-81.5)</code>
+                      <code>  (typedef-73.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -244358,8 +244358,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-81.1">
-          <h3>43.50. The complex type <code>group[siri:StopMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-81.1)</code>
+        <div class="sect2" id="local-type.typedef-73.1">
+          <h3>43.50. The complex type <code>group[siri:StopMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-73.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -244379,7 +244379,7 @@
                       <br/>
                       <code>  /MaximumNumberOfCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-81.1)</code>
+                      <code>  (typedef-73.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -244439,8 +244439,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-81.1">
-          <h3>43.51. The complex type <code>group[siri:StopMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-81.1)</code>
+        <div class="sect2" id="local-type.typedef-73.1">
+          <h3>43.51. The complex type <code>group[siri:StopMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-73.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -244460,7 +244460,7 @@
                       <br/>
                       <code>  /MaximumNumberOfCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-81.1)</code>
+                      <code>  (typedef-73.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -244520,8 +244520,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-81.2">
-          <h3>43.52. The complex type <code>complexType[siri:StopMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-81.2)</code>
+        <div class="sect2" id="local-type.typedef-73.2">
+          <h3>43.52. The complex type <code>complexType[siri:StopMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-73.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -244541,7 +244541,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-81.2)</code>
+                      <code>  (typedef-73.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -244734,8 +244734,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-81.3">
-          <h3>43.53. The complex type <code>complexType[siri:StopMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-81.3)</code>
+        <div class="sect2" id="local-type.typedef-73.3">
+          <h3>43.53. The complex type <code>complexType[siri:StopMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-73.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -244755,7 +244755,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-81.3)</code>
+                      <code>  (typedef-73.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -245095,8 +245095,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-81.4">
-          <h3>43.54. The complex type <code>complexType[siri:StopMonitoringServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-81.4)</code>
+        <div class="sect2" id="local-type.typedef-73.4">
+          <h3>43.54. The complex type <code>complexType[siri:StopMonitoringServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-73.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -245116,7 +245116,7 @@
                       <br/>
                       <code>  /ResponseFeatures #complexType</code>
                       <br/>
-                      <code>  (typedef-81.4)</code>
+                      <code>  (typedef-73.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -245176,8 +245176,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-36.1">
-          <h3>43.55. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-36.1)</code>
+        <div class="sect2" id="local-type.typedef-69.1">
+          <h3>43.55. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-69.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -245197,7 +245197,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-36.1)</code>
+                      <code>  (typedef-69.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -245265,8 +245265,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-56.2">
-          <h3>43.56. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-56.2)</code>
+        <div class="sect2" id="local-type.typedef-33.2">
+          <h3>43.56. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-33.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -245286,7 +245286,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-56.2)</code>
+                      <code>  (typedef-33.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -245371,8 +245371,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-56.1">
-          <h3>43.57. The complex type <code>element[siri:LinePermissions]#complexType (typedef-56.1)</code>
+        <div class="sect2" id="local-type.typedef-33.1">
+          <h3>43.57. The complex type <code>element[siri:LinePermissions]#complexType (typedef-33.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -245392,7 +245392,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-56.1)</code>
+                      <code>  (typedef-33.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -245477,8 +245477,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-81.6">
-          <h3>43.58. The complex type <code>complexType[siri:StopMonitoringServicePermissionStructure]/StopMonitorPermissions#complexType (typedef-81.6)</code>
+        <div class="sect2" id="local-type.typedef-73.6">
+          <h3>43.58. The complex type <code>complexType[siri:StopMonitoringServicePermissionStructure]/StopMonitorPermissions#complexType (typedef-73.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -245498,7 +245498,7 @@
                       <br/>
                       <code>  /StopMonitorPermissions #complexType</code>
                       <br/>
-                      <code>  (typedef-81.6)</code>
+                      <code>  (typedef-73.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -246642,7 +246642,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.3" title="local-type: typedef-82.3">local-type: typedef-82.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-85.3" title="local-type: typedef-85.3">local-type: typedef-85.3</a>
                       </em>
                     </p>
                   </td>
@@ -247786,7 +247786,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.1" title="local-type: typedef-82.1">local-type: typedef-82.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-85.1" title="local-type: typedef-85.1">local-type: typedef-85.1</a>
                       </em>
                     </p>
                   </td>
@@ -247834,7 +247834,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.2" title="local-type: typedef-82.2">local-type: typedef-82.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-85.2" title="local-type: typedef-85.2">local-type: typedef-85.2</a>
                       </em>
                     </p>
                   </td>
@@ -247993,7 +247993,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-69.1" title="local-type: typedef-69.1">local-type: typedef-69.1</a>
                       </em>
                     </p>
                   </td>
@@ -248027,7 +248027,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-56.2" title="local-type: typedef-56.2">local-type: typedef-56.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-33.2" title="local-type: typedef-33.2">local-type: typedef-33.2</a>
                       </em>
                     </p>
                   </td>
@@ -248056,7 +248056,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-56.1" title="local-type: typedef-56.1">local-type: typedef-56.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-33.1" title="local-type: typedef-33.1">local-type: typedef-33.1</a>
                       </em>
                     </p>
                   </td>
@@ -248084,7 +248084,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-82.4" title="local-type: typedef-82.4">local-type: typedef-82.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-85.4" title="local-type: typedef-85.4">local-type: typedef-85.4</a>
                       </em>
                     </p>
                   </td>
@@ -249040,8 +249040,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.3">
-          <h3>44.23. The complex type <code>element[siri:StopTimetablePermissions]#complexType (typedef-82.3)</code>
+        <div class="sect2" id="local-type.typedef-85.3">
+          <h3>44.23. The complex type <code>element[siri:StopTimetablePermissions]#complexType (typedef-85.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -249061,7 +249061,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.3)</code>
+                      <code>  (typedef-85.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -249135,8 +249135,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.3">
-          <h3>44.24. The complex type <code>element[siri:StopTimetablePermissions]#complexType (typedef-82.3)</code>
+        <div class="sect2" id="local-type.typedef-85.3">
+          <h3>44.24. The complex type <code>element[siri:StopTimetablePermissions]#complexType (typedef-85.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -249156,7 +249156,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-82.3)</code>
+                      <code>  (typedef-85.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -249230,8 +249230,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.1">
-          <h3>44.25. The complex type <code>complexType[siri:StopTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-82.1)</code>
+        <div class="sect2" id="local-type.typedef-85.1">
+          <h3>44.25. The complex type <code>complexType[siri:StopTimetableServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-85.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -249251,7 +249251,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-82.1)</code>
+                      <code>  (typedef-85.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -249345,8 +249345,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.2">
-          <h3>44.26. The complex type <code>complexType[siri:StopTimetableServiceCapabilitiesStructure]/AccessControl#complexType (typedef-82.2)</code>
+        <div class="sect2" id="local-type.typedef-85.2">
+          <h3>44.26. The complex type <code>complexType[siri:StopTimetableServiceCapabilitiesStructure]/AccessControl#complexType (typedef-85.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -249366,7 +249366,7 @@
                       <br/>
                       <code>  /AccessControl #complexType</code>
                       <br/>
-                      <code>  (typedef-82.2)</code>
+                      <code>  (typedef-85.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -249491,8 +249491,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-36.1">
-          <h3>44.27. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-36.1)</code>
+        <div class="sect2" id="local-type.typedef-69.1">
+          <h3>44.27. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-69.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -249512,7 +249512,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-36.1)</code>
+                      <code>  (typedef-69.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -249580,8 +249580,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-56.2">
-          <h3>44.28. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-56.2)</code>
+        <div class="sect2" id="local-type.typedef-33.2">
+          <h3>44.28. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-33.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -249601,7 +249601,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-56.2)</code>
+                      <code>  (typedef-33.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -249686,8 +249686,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-56.1">
-          <h3>44.29. The complex type <code>element[siri:LinePermissions]#complexType (typedef-56.1)</code>
+        <div class="sect2" id="local-type.typedef-33.1">
+          <h3>44.29. The complex type <code>element[siri:LinePermissions]#complexType (typedef-33.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -249707,7 +249707,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-56.1)</code>
+                      <code>  (typedef-33.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -249792,8 +249792,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-82.4">
-          <h3>44.30. The complex type <code>complexType[siri:StopTimetableServicePermissionStructure]/StopMonitorPermissions#complexType (typedef-82.4)</code>
+        <div class="sect2" id="local-type.typedef-85.4">
+          <h3>44.30. The complex type <code>complexType[siri:StopTimetableServicePermissionStructure]/StopMonitorPermissions#complexType (typedef-85.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -249813,7 +249813,7 @@
                       <br/>
                       <code>  /StopMonitorPermissions #complexType</code>
                       <br/>
-                      <code>  (typedef-82.4)</code>
+                      <code>  (typedef-85.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -251214,7 +251214,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-69.1" title="local-type: typedef-69.1">local-type: typedef-69.1</a>
                       </em>
                     </p>
                   </td>
@@ -251342,8 +251342,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-36.1">
-          <h3>47.5. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-36.1)</code>
+        <div class="sect2" id="local-type.typedef-69.1">
+          <h3>47.5. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-69.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -251363,7 +251363,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-36.1)</code>
+                      <code>  (typedef-69.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -251626,12 +251626,12 @@
                 </tr>
                 <tr>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
-                    <p id="local-type.typedef-24.1" class="tableblock">
+                    <p id="local-type.typedef-1.1" class="tableblock">
                       <code>attribute[lang]</code>
                       <br/>
                       <code>  #simpleType</code>
                       <br/>
-                      <code>  (typedef-24.1)</code>
+                      <code>  (typedef-1.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -253905,7 +253905,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.1" title="local-type: typedef-80.1">local-type: typedef-80.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.1" title="local-type: typedef-79.1">local-type: typedef-79.1</a>
                       </em>
                     </p>
                   </td>
@@ -255028,7 +255028,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.2" title="local-type: typedef-80.2">local-type: typedef-80.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.2" title="local-type: typedef-79.2">local-type: typedef-79.2</a>
                       </em>
                     </p>
                   </td>
@@ -255342,7 +255342,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.7" title="local-type: typedef-80.7">local-type: typedef-80.7</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.7" title="local-type: typedef-79.7">local-type: typedef-79.7</a>
                       </em>
                     </p>
                   </td>
@@ -256482,7 +256482,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.1" title="local-type: typedef-80.1">local-type: typedef-80.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.1" title="local-type: typedef-79.1">local-type: typedef-79.1</a>
                       </em>
                     </p>
                   </td>
@@ -256642,7 +256642,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.3" title="local-type: typedef-80.3">local-type: typedef-80.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.3" title="local-type: typedef-79.3">local-type: typedef-79.3</a>
                       </em>
                     </p>
                   </td>
@@ -256666,7 +256666,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.4" title="local-type: typedef-80.4">local-type: typedef-80.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.4" title="local-type: typedef-79.4">local-type: typedef-79.4</a>
                       </em>
                     </p>
                   </td>
@@ -256714,7 +256714,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.5" title="local-type: typedef-80.5">local-type: typedef-80.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.5" title="local-type: typedef-79.5">local-type: typedef-79.5</a>
                       </em>
                     </p>
                   </td>
@@ -256738,7 +256738,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.6" title="local-type: typedef-80.6">local-type: typedef-80.6</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.6" title="local-type: typedef-79.6">local-type: typedef-79.6</a>
                       </em>
                     </p>
                   </td>
@@ -256897,7 +256897,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-36.1" title="local-type: typedef-36.1">local-type: typedef-36.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-69.1" title="local-type: typedef-69.1">local-type: typedef-69.1</a>
                       </em>
                     </p>
                   </td>
@@ -256931,7 +256931,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-56.2" title="local-type: typedef-56.2">local-type: typedef-56.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-33.2" title="local-type: typedef-33.2">local-type: typedef-33.2</a>
                       </em>
                     </p>
                   </td>
@@ -256960,7 +256960,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-56.1" title="local-type: typedef-56.1">local-type: typedef-56.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-33.1" title="local-type: typedef-33.1">local-type: typedef-33.1</a>
                       </em>
                     </p>
                   </td>
@@ -256988,7 +256988,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-80.8" title="local-type: typedef-80.8">local-type: typedef-80.8</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-79.8" title="local-type: typedef-79.8">local-type: typedef-79.8</a>
                       </em>
                     </p>
                   </td>
@@ -257401,8 +257401,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.7">
-          <h3>50.30. The complex type <code>element[siri:VehicleMonitoringPermissions]#complexType (typedef-80.7)</code>
+        <div class="sect2" id="local-type.typedef-79.7">
+          <h3>50.30. The complex type <code>element[siri:VehicleMonitoringPermissions]#complexType (typedef-79.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -257422,7 +257422,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-80.7)</code>
+                      <code>  (typedef-79.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -257496,8 +257496,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.1">
-          <h3>50.31. The complex type <code>group[siri:VehicleMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-80.1)</code>
+        <div class="sect2" id="local-type.typedef-79.1">
+          <h3>50.31. The complex type <code>group[siri:VehicleMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-79.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -257517,7 +257517,7 @@
                       <br/>
                       <code>  /MaximumNumberOfCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-80.1)</code>
+                      <code>  (typedef-79.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -257577,8 +257577,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.2">
-          <h3>50.32. The complex type <code>complexType[siri:VehicleActivityStructure]/MonitoredVehicleJourney#complexType (typedef-80.2)</code>
+        <div class="sect2" id="local-type.typedef-79.2">
+          <h3>50.32. The complex type <code>complexType[siri:VehicleActivityStructure]/MonitoredVehicleJourney#complexType (typedef-79.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -257598,7 +257598,7 @@
                       <br/>
                       <code>  /MonitoredVehicleJourney #complexType</code>
                       <br/>
-                      <code>  (typedef-80.2)</code>
+                      <code>  (typedef-79.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -258040,7 +258040,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -258061,7 +258061,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -258082,7 +258082,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -258167,7 +258167,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -258188,7 +258188,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguagePlaceNameStructure" title="siri:NaturalLanguagePlaceNameStructure">siri:NaturalLanguagePlaceNameStructure</a>
+                      <em>&gt;<a shape="rect" href="#type.siri:NaturalLanguageStringStructure" title="siri:NaturalLanguageStringStructure">siri:NaturalLanguageStringStructure</a>
                       </em>
                     </p>
                   </td>
@@ -259065,7 +259065,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-57.4" title="local-type: typedef-57.4">local-type: typedef-57.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.4" title="local-type: typedef-50.4">local-type: typedef-50.4</a>
                       </em>
                     </p>
                   </td>
@@ -259086,7 +259086,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-57.5" title="local-type: typedef-57.5">local-type: typedef-57.5</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-50.5" title="local-type: typedef-50.5">local-type: typedef-50.5</a>
                       </em>
                     </p>
                   </td>
@@ -259110,7 +259110,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.2" title="local-type: typedef-50.2">local-type: typedef-50.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.2" title="local-type: typedef-35.2">local-type: typedef-35.2</a>
                       </em>
                     </p>
                   </td>
@@ -259131,7 +259131,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.3" title="local-type: typedef-50.3">local-type: typedef-50.3</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.3" title="local-type: typedef-35.3">local-type: typedef-35.3</a>
                       </em>
                     </p>
                   </td>
@@ -259152,7 +259152,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-50.4" title="local-type: typedef-50.4">local-type: typedef-50.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-35.4" title="local-type: typedef-35.4">local-type: typedef-35.4</a>
                       </em>
                     </p>
                   </td>
@@ -259250,8 +259250,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-57.4">
-          <h3>50.33. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-57.4)</code>
+        <div class="sect2" id="local-type.typedef-50.4">
+          <h3>50.33. The complex type <code>group[siri:TrainOperationalInfoGroup]/TrainNumbers#complexType (typedef-50.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -259271,7 +259271,7 @@
                       <br/>
                       <code>  /TrainNumbers #complexType</code>
                       <br/>
-                      <code>  (typedef-57.4)</code>
+                      <code>  (typedef-50.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -259313,8 +259313,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-57.5">
-          <h3>50.34. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-57.5)</code>
+        <div class="sect2" id="local-type.typedef-50.5">
+          <h3>50.34. The complex type <code>group[siri:TrainOperationalInfoGroup]/JourneyParts#complexType (typedef-50.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -259334,7 +259334,7 @@
                       <br/>
                       <code>  /JourneyParts #complexType</code>
                       <br/>
-                      <code>  (typedef-57.5)</code>
+                      <code>  (typedef-50.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -259376,8 +259376,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.2">
-          <h3>50.35. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-50.2)</code>
+        <div class="sect2" id="local-type.typedef-35.2">
+          <h3>50.35. The complex type <code>group[siri:JourneyFormationGroup]/TrainElements#complexType (typedef-35.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -259397,7 +259397,7 @@
                       <br/>
                       <code>  /TrainElements #complexType</code>
                       <br/>
-                      <code>  (typedef-50.2)</code>
+                      <code>  (typedef-35.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -259484,8 +259484,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.3">
-          <h3>50.36. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-50.3)</code>
+        <div class="sect2" id="local-type.typedef-35.3">
+          <h3>50.36. The complex type <code>group[siri:JourneyFormationGroup]/Trains#complexType (typedef-35.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -259505,7 +259505,7 @@
                       <br/>
                       <code>  /Trains #complexType</code>
                       <br/>
-                      <code>  (typedef-50.3)</code>
+                      <code>  (typedef-35.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -259592,8 +259592,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-50.4">
-          <h3>50.37. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-50.4)</code>
+        <div class="sect2" id="local-type.typedef-35.4">
+          <h3>50.37. The complex type <code>group[siri:JourneyFormationGroup]/CompoundTrains#complexType (typedef-35.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -259613,7 +259613,7 @@
                       <br/>
                       <code>  /CompoundTrains #complexType</code>
                       <br/>
-                      <code>  (typedef-50.4)</code>
+                      <code>  (typedef-35.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -259700,8 +259700,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.7">
-          <h3>50.38. The complex type <code>element[siri:VehicleMonitoringPermissions]#complexType (typedef-80.7)</code>
+        <div class="sect2" id="local-type.typedef-79.7">
+          <h3>50.38. The complex type <code>element[siri:VehicleMonitoringPermissions]#complexType (typedef-79.7)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -259721,7 +259721,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-80.7)</code>
+                      <code>  (typedef-79.7)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -259795,8 +259795,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.1">
-          <h3>50.39. The complex type <code>group[siri:VehicleMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-80.1)</code>
+        <div class="sect2" id="local-type.typedef-79.1">
+          <h3>50.39. The complex type <code>group[siri:VehicleMonitoringRequestPolicyGroup]/MaximumNumberOfCalls#complexType (typedef-79.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -259816,7 +259816,7 @@
                       <br/>
                       <code>  /MaximumNumberOfCalls #complexType</code>
                       <br/>
-                      <code>  (typedef-80.1)</code>
+                      <code>  (typedef-79.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -259876,8 +259876,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.3">
-          <h3>50.40. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-80.3)</code>
+        <div class="sect2" id="local-type.typedef-79.3">
+          <h3>50.40. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/TopicFiltering#complexType (typedef-79.3)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -259897,7 +259897,7 @@
                       <br/>
                       <code>  /TopicFiltering #complexType</code>
                       <br/>
-                      <code>  (typedef-80.3)</code>
+                      <code>  (typedef-79.3)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -260039,8 +260039,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.4">
-          <h3>50.41. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-80.4)</code>
+        <div class="sect2" id="local-type.typedef-79.4">
+          <h3>50.41. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/RequestPolicy#complexType (typedef-79.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -260060,7 +260060,7 @@
                       <br/>
                       <code>  /RequestPolicy #complexType</code>
                       <br/>
-                      <code>  (typedef-80.4)</code>
+                      <code>  (typedef-79.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -260334,8 +260334,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.5">
-          <h3>50.42. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/AccessControl#complexType (typedef-80.5)</code>
+        <div class="sect2" id="local-type.typedef-79.5">
+          <h3>50.42. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/AccessControl#complexType (typedef-79.5)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -260355,7 +260355,7 @@
                       <br/>
                       <code>  /AccessControl #complexType</code>
                       <br/>
-                      <code>  (typedef-80.5)</code>
+                      <code>  (typedef-79.5)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -260479,8 +260479,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.6">
-          <h3>50.43. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-80.6)</code>
+        <div class="sect2" id="local-type.typedef-79.6">
+          <h3>50.43. The complex type <code>complexType[siri:VehicleMonitoringServiceCapabilitiesStructure]/ResponseFeatures#complexType (typedef-79.6)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -260500,7 +260500,7 @@
                       <br/>
                       <code>  /ResponseFeatures #complexType</code>
                       <br/>
-                      <code>  (typedef-80.6)</code>
+                      <code>  (typedef-79.6)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -260560,8 +260560,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-36.1">
-          <h3>50.44. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-36.1)</code>
+        <div class="sect2" id="local-type.typedef-69.1">
+          <h3>50.44. The complex type <code>complexType[siri:AbstractPermissionStructure]/GeneralCapabilities#complexType (typedef-69.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -260581,7 +260581,7 @@
                       <br/>
                       <code>  /GeneralCapabilities #complexType</code>
                       <br/>
-                      <code>  (typedef-36.1)</code>
+                      <code>  (typedef-69.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -260649,8 +260649,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-56.2">
-          <h3>50.45. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-56.2)</code>
+        <div class="sect2" id="local-type.typedef-33.2">
+          <h3>50.45. The complex type <code>element[siri:OperatorPermissions]#complexType (typedef-33.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -260670,7 +260670,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-56.2)</code>
+                      <code>  (typedef-33.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -260755,8 +260755,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-56.1">
-          <h3>50.46. The complex type <code>element[siri:LinePermissions]#complexType (typedef-56.1)</code>
+        <div class="sect2" id="local-type.typedef-33.1">
+          <h3>50.46. The complex type <code>element[siri:LinePermissions]#complexType (typedef-33.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -260776,7 +260776,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-56.1)</code>
+                      <code>  (typedef-33.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -260861,8 +260861,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-80.8">
-          <h3>50.47. The complex type <code>complexType[siri:VehicleMonitoringServicePermissionStructure]/VehicleMonitoringPermissions#complexType (typedef-80.8)</code>
+        <div class="sect2" id="local-type.typedef-79.8">
+          <h3>50.47. The complex type <code>complexType[siri:VehicleMonitoringServicePermissionStructure]/VehicleMonitoringPermissions#complexType (typedef-79.8)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -260882,7 +260882,7 @@
                       <br/>
                       <code>  /VehicleMonitoringPermissions #complexType</code>
                       <br/>
-                      <code>  (typedef-80.8)</code>
+                      <code>  (typedef-79.8)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -261065,7 +261065,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.2" title="local-type: typedef-75.2">local-type: typedef-75.2</a>
                       </em>
                     </p>
                   </td>
@@ -261096,7 +261096,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-33.2" title="local-type: typedef-33.2">local-type: typedef-33.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-19.2" title="local-type: typedef-19.2">local-type: typedef-19.2</a>
                       </em>
                     </p>
                   </td>
@@ -261482,7 +261482,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.4" title="local-type: typedef-77.4">local-type: typedef-77.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.4" title="local-type: typedef-75.4">local-type: typedef-75.4</a>
                       </em>
                     </p>
                   </td>
@@ -261664,8 +261664,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-84.1">
-          <h3>51.2. The complex type <code>element[siri:Siri]#complexType (typedef-84.1)</code>
+        <div class="sect2" id="local-type.typedef-78.1">
+          <h3>51.2. The complex type <code>element[siri:Siri]#complexType (typedef-78.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -261685,7 +261685,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-84.1)</code>
+                      <code>  (typedef-78.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -261763,7 +261763,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.2" title="local-type: typedef-77.2">local-type: typedef-77.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.2" title="local-type: typedef-75.2">local-type: typedef-75.2</a>
                       </em>
                     </p>
                   </td>
@@ -261794,7 +261794,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-33.2" title="local-type: typedef-33.2">local-type: typedef-33.2</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-19.2" title="local-type: typedef-19.2">local-type: typedef-19.2</a>
                       </em>
                     </p>
                   </td>
@@ -262180,7 +262180,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-77.4" title="local-type: typedef-77.4">local-type: typedef-77.4</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-75.4" title="local-type: typedef-75.4">local-type: typedef-75.4</a>
                       </em>
                     </p>
                   </td>
@@ -262362,8 +262362,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.2">
-          <h3>51.3. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-77.2)</code>
+        <div class="sect2" id="local-type.typedef-75.2">
+          <h3>51.3. The complex type <code>element[siri:ServiceRequest]#complexType (typedef-75.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -262383,7 +262383,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.2)</code>
+                      <code>  (typedef-75.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -262617,8 +262617,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-33.2">
-          <h3>51.4. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-33.2)</code>
+        <div class="sect2" id="local-type.typedef-19.2">
+          <h3>51.4. The complex type <code>element[siri:SubscriptionRequest]#complexType (typedef-19.2)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -262638,7 +262638,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-33.2)</code>
+                      <code>  (typedef-19.2)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -262946,8 +262946,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-77.4">
-          <h3>51.5. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-77.4)</code>
+        <div class="sect2" id="local-type.typedef-75.4">
+          <h3>51.5. The complex type <code>element[siri:ServiceDelivery]#complexType (typedef-75.4)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -262967,7 +262967,7 @@
                       <br/>
                       <code>  #complexType</code>
                       <br/>
-                      <code>  (typedef-77.4)</code>
+                      <code>  (typedef-75.4)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
@@ -263211,7 +263211,7 @@
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
-                      <em>+<a shape="rect" href="#local-type.typedef-34.1" title="local-type: typedef-34.1">local-type: typedef-34.1</a>
+                      <em>+<a shape="rect" href="#local-type.typedef-18.1" title="local-type: typedef-18.1">local-type: typedef-18.1</a>
                       </em>
                     </p>
                   </td>
@@ -263272,8 +263272,8 @@
             </table>
           </div>
         </div>
-        <div class="sect2" id="local-type.typedef-34.1">
-          <h3>51.6. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-34.1)</code>
+        <div class="sect2" id="local-type.typedef-18.1">
+          <h3>51.6. The complex type <code>group[siri:ServiceDeliveryRequestStatusGroup]/ErrorCondition#complexType (typedef-18.1)</code>
           </h3>
           <div class="sectionbody">
             <table class="tableblock frame-all grid-all spread">
@@ -263293,7 +263293,7 @@
                       <br/>
                       <code>  /ErrorCondition #complexType</code>
                       <br/>
-                      <code>  (typedef-34.1)</code>
+                      <code>  (typedef-18.1)</code>
                     </p>
                   </td>
                   <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">

--- a/xsd/siri_model/siri_datedVehicleJourney.xsd
+++ b/xsd/siri_model/siri_datedVehicleJourney.xsd
@@ -185,7 +185,7 @@ Rail transport, Roads and road transport
 					<xsd:documentation>Description of the destination stop (vehicle signage) to show on vehicle, Can be overwritten for a journey, and then also section by section by the entry in an Individual Call.  (Unbounded since SIRI 2.0)</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="LineNote" type="NaturalLanguagePlaceNameStructure" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element name="LineNote" type="NaturalLanguageStringStructure" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Additional Text associated with LINE.  (Unbounded since SIRI 2.0)</xsd:documentation>
 				</xsd:annotation>

--- a/xsd/siri_model/siri_journey.xsd
+++ b/xsd/siri_model/siri_journey.xsd
@@ -191,17 +191,17 @@ Rail transport, Roads and road transport
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element ref="OriginRef" minOccurs="0"/>
-			<xsd:element name="OriginName" type="NaturalLanguagePlaceNameStructure" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element name="OriginName" type="NaturalLanguageStringStructure" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Name of the origin of the journey.  (Unbounded since SIRI 2.0)</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="OriginShortName" type="NaturalLanguagePlaceNameStructure" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element name="OriginShortName" type="NaturalLanguageStringStructure" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Short name of the origin of the journey; used to help identify the VEHICLE JOURNEY on arrival boards. If absent, same as Origin Name.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="DestinationDisplayAtOrigin" type="NaturalLanguagePlaceNameStructure" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element name="DestinationDisplayAtOrigin" type="NaturalLanguageStringStructure" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>DIRECTION name shown for jurney at the origin. (since SIRI 2.0)</xsd:documentation>
 				</xsd:annotation>
@@ -221,12 +221,12 @@ Rail transport, Roads and road transport
 					<xsd:documentation>Description of the destination stop (vehicle signage), Can be overwritten for a journey, and then also section by section by the entry in an individual CALl.  (Unbounded since SIRI 2.0)</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="DestinationShortName" type="NaturalLanguagePlaceNameStructure" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element name="DestinationShortName" type="NaturalLanguageStringStructure" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Short name of the DESTINATION.of the journey; used to help identify the VEHICLE JOURNEY on arrival boards. If absent, same as DestinationName.  (Unbounded since SIRI 2.0)</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="OriginDisplayAtDestination" type="NaturalLanguagePlaceNameStructure" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element name="OriginDisplayAtDestination" type="NaturalLanguageStringStructure" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>Origin name shown for jourey at the destination (since SIRI 2.0)</xsd:documentation>
 				</xsd:annotation>

--- a/xsd/siri_model/siri_situationAffects.xsd
+++ b/xsd/siri_model/siri_situationAffects.xsd
@@ -929,12 +929,12 @@ Rail transport, Roads and road transport
 					<xsd:documentation>Timetabled arrival time of journey at Destination.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="OriginDisplayAtDestination" type="NaturalLanguagePlaceNameStructure" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element name="OriginDisplayAtDestination" type="NaturalLanguageStringStructure" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>DESTINATION name shown for journey at the origin. Can be Used to identify journey for user. (since SIRI 2.0), </xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="DestinationDisplayAtOrigin" type="NaturalLanguagePlaceNameStructure" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element name="DestinationDisplayAtOrigin" type="NaturalLanguageStringStructure" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>DESTINATION name shown for journey at the origin.  Can be Used to identify journey for user. (since SIRI 2.0)</xsd:documentation>
 				</xsd:annotation>


### PR DESCRIPTION
NaturalLanguagePlaceNameStructure is too restrictive and therefore not usable in regions where stop names often contain commas. Also, in some instances the same or similar elements in other service specifications already uses a different type NaturalLanguageStringStructure which is conflicting. 

The pull request aimes to harmonize all of these related elements for declaration of origin/destination and extends the allowed characters accordingly.

Alternatively, or additionally, an update of the underlying PopulatedStringType is proposed (to remove comma in the pattern restriction):
`<xsd:restriction base="PopulatedStringType">`
`    <xsd:pattern value="[^\[\]\{\}\?$%\^=@#;:]+"/>`
`</xsd:restriction>`