### PR TITLE
Added restriction for PositiveDurationType in XSD

### DIFF
--- a/xsd/siri_utility/siri_types.xsd
+++ b/xsd/siri_utility/siri_types.xsd
@@ -123,7 +123,9 @@ A string containing a phrase in a natural language name that requires at least o
 		<xsd:annotation>
 			<xsd:documentation>Limited version of duration. Must be positive.</xsd:documentation>
 		</xsd:annotation>
-		<xsd:restriction base="DurationType"/>
+		<xsd:restriction base="DurationType">
+			<xsd:minInclusive value="PT0S"/>
+		</xsd:restriction>
 	</xsd:simpleType>
 	<xsd:simpleType name="PhoneType">
 		<xsd:annotation>


### PR DESCRIPTION
Positive Duration's had not to be positive - this PR adds a validation for that bug