### PR TITLE
add new value to ServiceConditionEnumeration

### DIFF
--- a/docs/generated/contab/siri.html
+++ b/docs/generated/contab/siri.html
@@ -212092,6 +212092,14 @@
                         </tr>
                         <tr>
                           <td class="tableblock halign-left valign-top">
+                            <p class="tableblock">mobilityImpairedAccessLimited</p>
+                          </td>
+                          <td class="tableblock halign-left valign-top">
+                            <p class="tableblock anno-text">Access for mobility impaired passengers limited</p>
+                          </td>
+                        </tr>
+                        <tr>
+                          <td class="tableblock halign-left valign-top">
                             <p class="tableblock">undefinedStatus</p>
                           </td>
                           <td class="tableblock halign-left valign-top">

--- a/xsd/siri_model/siri_situationClassifiers.xsd
+++ b/xsd/siri_model/siri_situationClassifiers.xsd
@@ -273,7 +273,7 @@ Rail transport, Roads and road transport
 			</xsd:enumeration>
 			<xsd:enumeration value="mobilityImpairedAccessLimited">
 				<xsd:annotation>
-					<xsd:documentation>Access is limited for mobility impaired passengers. The value should correspond the the overall summary of the AccessibilityAssessment of the StopPoint, when known. +v2.3</xsd:documentation>
+					<xsd:documentation>Access is limited for mobility impaired passengers. The value should correspond to the overall summary of the AccessibilityAssessment of the StopPoint, when known. +v2.3</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="undefinedStatus">

--- a/xsd/siri_model/siri_situationClassifiers.xsd
+++ b/xsd/siri_model/siri_situationClassifiers.xsd
@@ -271,6 +271,11 @@ Rail transport, Roads and road transport
 					<xsd:documentation>TPEG Pts43_27, temporary stopplace</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
+			<xsd:enumeration value="mobilityImpairedAccessLimited">
+				<xsd:annotation>
+					<xsd:documentation>Access for mobility impaired passengers limited</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 			<xsd:enumeration value="undefinedStatus">
 				<xsd:annotation>
 					<xsd:documentation>TPEG Pts43_255, undefined status</xsd:documentation>

--- a/xsd/siri_model/siri_situationClassifiers.xsd
+++ b/xsd/siri_model/siri_situationClassifiers.xsd
@@ -273,7 +273,7 @@ Rail transport, Roads and road transport
 			</xsd:enumeration>
 			<xsd:enumeration value="mobilityImpairedAccessLimited">
 				<xsd:annotation>
-					<xsd:documentation>Access is limited for mobility impaired passengers. +v2.3</xsd:documentation>
+					<xsd:documentation>Access is limited for mobility impaired passengers. The value should correspond the the overall summary of the AccessibilityAssessment of the StopPoint, when known. +v2.3</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="undefinedStatus">

--- a/xsd/siri_model/siri_situationClassifiers.xsd
+++ b/xsd/siri_model/siri_situationClassifiers.xsd
@@ -273,7 +273,7 @@ Rail transport, Roads and road transport
 			</xsd:enumeration>
 			<xsd:enumeration value="mobilityImpairedAccessLimited">
 				<xsd:annotation>
-					<xsd:documentation>Access for mobility impaired passengers limited</xsd:documentation>
+					<xsd:documentation>Access is limited for mobility impaired passengers. +v2.3</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="undefinedStatus">


### PR DESCRIPTION
Currently there's no appropriate value for Condition (within PtSituationElement.Consequence as part of an SX message) in case the AccessibilityAssessment, for example of an AffectedStopPoint, is updated as a consequence of a situation.