### PR TITLE
Service link proposal v2

### DIFF
--- a/xsd/siri_controlAction_service.xsd
+++ b/xsd/siri_controlAction_service.xsd
@@ -1197,11 +1197,18 @@ Can be used  when stops are replaced by other stops on certain journeys</xsd:doc
 					<xsd:documentation>Identification of the DATED VEHICLE JOURNEY to be changed</xsd:documentation>
 				</xsd:annotation>
 			</xsd:group>
-			<xsd:element name="ChangedPoints" type="ChangedPoints">
-				<xsd:annotation>
-					<xsd:documentation>List of modified points</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
+			<xsd:choice>
+				<xsd:element name="ChangedPoints" type="ChangedPoints">
+					<xsd:annotation>
+						<xsd:documentation>List of modified points</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element name="UpdatedServiceLinks" type="ServiceLinkViewsStructure">
+					<xsd:annotation>
+						<xsd:documentation>List of SERVICE LINKs having updated shapes in that journey. This is only to provide updated the shapes of the journey (as gml:linestring), not to provide additional SERVICE LINK (provided through the sequence of CALLS)</xsd:documentation>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:choice>
 		</xsd:sequence>
 	</xsd:complexType>
 	<!--  *********************************************************  -->

--- a/xsd/siri_model/siri_estimatedVehicleJourney.xsd
+++ b/xsd/siri_model/siri_estimatedVehicleJourney.xsd
@@ -363,11 +363,6 @@ the original journey and the nature of the difference.</xsd:documentation>
 					<xsd:documentation>Relations of the journey with other journeys, e.g., in case a joining/splitting takes place or the journey substitutes for another one etc.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="UpdatedServiceLinks" type="ServiceLinkViewsStructure" minOccurs="0">
-				<xsd:annotation>
-					<xsd:documentation>List of SERVICE LINKs having updated shapes in that journey. This is only to provide updated the shapes of the journey (as gml:linestring), not to provide additional SERVICE LINK (provided through the sequence of CALLS)</xsd:documentation>
-				</xsd:annotation>
-			</xsd:element>
 			<xsd:element ref="Extensions" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:complexType>

--- a/xsd/siri_model/siri_estimatedVehicleJourney.xsd
+++ b/xsd/siri_model/siri_estimatedVehicleJourney.xsd
@@ -363,6 +363,11 @@ the original journey and the nature of the difference.</xsd:documentation>
 					<xsd:documentation>Relations of the journey with other journeys, e.g., in case a joining/splitting takes place or the journey substitutes for another one etc.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="UpdatedServiceLinks" type="ServiceLinkViewsStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>List of SERVICE LINKs having updated shapes in that journey. This is only to provide updated the shapes of the journey (as gml:linestring), not to provide additional SERVICE LINK (provided through the sequence of CALLS)</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element ref="Extensions" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:complexType>

--- a/xsd/siri_model/siri_journey.xsd
+++ b/xsd/siri_model/siri_journey.xsd
@@ -132,6 +132,8 @@ Rail transport, Roads and road transport
 	<xsd:import namespace="http://www.ifopt.org.uk/ifopt" schemaLocation="../ifopt/ifopt_allStopPlace.xsd"/>
 	<!-- Global import of all ACSB namespace elements used in SIRI needed to work around JAXB/XERCES/xmllint limitations -->
 	<xsd:import namespace="http://www.ifopt.org.uk/acsb" schemaLocation="../acsb/acsb_all.xsd"/>
+	<!-- For GML (GIS features) -->
+	<xsd:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="../gml/gml_extract_all_objects.xsd"/>
 	<!-- ==== VEHICLEJOURNEY ================================================================== -->
 	<xsd:group name="JourneyInfoGroup">
 		<xsd:annotation>
@@ -1907,5 +1909,40 @@ TRAINs within a COMPOUND TRAIN may have different origins and destinations due t
 			</xsd:element>
 		</xsd:sequence>
 	</xsd:group>
-	<!-- ======================================================================================================== -->
+	<!-- Service Links ======================================================================= -->
+		<xsd:complexType name="ServiceLinkViewsStructure">
+		<xsd:annotation>
+			<xsd:documentation>Provides information about updated SERVICE LINKs</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="ServiceLinkView" type="ServiceLinkViewStructure" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="ServiceLinkViewStructure">
+		<xsd:annotation>
+			<xsd:documentation>Simplified description of an update of a SERVICE LINK, in order to provide an updated schematic shape (not ROUTE POINTs) in case of rerouting. Only updated ServiceLink are expected to be provided here, the scheduled one being provided by a NeTEx feed. The SERVICE JOURNEY itself is knonw from hte context</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="FromStopPointRef" type="StopPointRefStructure">
+				<xsd:annotation>
+					<xsd:documentation>Reference to the SCHEDULED STOP POINT at which the related SERVICE LINK begins.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="ToStopPointRef" type="StopPointRefStructure">
+				<xsd:annotation>
+					<xsd:documentation>Reference to the SCHEDULED STOP POINT at which the related SERVICE LINK ends.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="Distance" type="LengthType" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Length of LINK.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element ref="gml:LineString" minOccurs="1">
+				<xsd:annotation>
+					<xsd:documentation>The shape (LineString) is mandatory in order to be consistent with the use case, which is to update the shape</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
 </xsd:schema>

--- a/xsd/siri_model/siri_situation.xsd
+++ b/xsd/siri_model/siri_situation.xsd
@@ -1300,6 +1300,11 @@ Note that if the ControlAction is the master ControlAction of a GroupOfControlAc
 					<xsd:documentation>Description of fare exceptions allowed because of disruption.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+			<xsd:element name="UpdatedServiceLinks" type="ServiceLinkViewsStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>List of SERVICE LINKs having updated shapes in that journey. This is only to provide updated the shapes of the journey (as gml:linestring), not to provide additional SERVICE LINK (provided through the sequence of CALLS)</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
 			<xsd:element ref="Extensions" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:complexType>


### PR DESCRIPTION
**_Second proposal to include ServiceLinks updates_**
Takes into account the decision from the September 24th 2025 meeting (remove it from ET and add to CA)
Replaces https://github.com/SIRI-CEN/SIRI/pull/175

Provides a simplified description of an update of a SERVICE LINK, in order to provide an updated schematic shape (not ROUTE POINTs) in case of rerouting. Only updated ServiceLink are expected to be provided here, the scheduled one being provided by a NeTEx feed. The SERVICE JOURNEY itself is known from the context.
Note that, The shape (LineString) is mandatory in order to be consistent with the use case, which is to update the shape.
In this initial proposal, the Service Links update can be inserted either in a ChangeOfJourneyPattern ControlAction (to be repeated for each journey) either in a consequence of a PTSituation (can be shared accross multiple journeys). 
Also note that an EstimatedVehicleJourneyStructure can be refer PTSituations containing the UpdatedServiceLinks information.