### PR TITLE
Removing deprecation notes for DatedVehicleJourney

### DIFF
--- a/xsd/siri_model/siri_estimatedVehicleJourney.xsd
+++ b/xsd/siri_model/siri_estimatedVehicleJourney.xsd
@@ -114,8 +114,7 @@ Rail transport, Roads and road transport
 						</xsd:element>
 						<xsd:element name="DatedVehicleJourneyRef" type="DatedVehicleJourneyRefStructure">
 							<xsd:annotation>
-								<xsd:documentation>Reference to a dated VEHICLE JOURNEY. This will be 'framed' i.e. be with the data context of the ESTIMATED Timetable.
-DEPRECATED from SIRI 2.0</xsd:documentation>
+								<xsd:documentation>Reference to a dated VEHICLE JOURNEY. This will be 'framed' i.e. be with the data context of the ESTIMATED Timetable.</xsd:documentation>
 							</xsd:annotation>
 						</xsd:element>
 					</xsd:choice>
@@ -127,8 +126,7 @@ DEPRECATED from SIRI 2.0</xsd:documentation>
 				</xsd:sequence>
 				<xsd:element name="EstimatedVehicleJourneyCode" type="EstimatedVehicleJourneyCodeType">
 					<xsd:annotation>
-						<xsd:documentation>If this is the first message for an unplanned 'extra' VEHICLE JOURNEY, a new and unique code must be given for it. ExtraJourney should be set to 'true'.
-DEPRECATED from SIRI 2.0</xsd:documentation>
+						<xsd:documentation>If this is the first message for an unplanned 'extra' VEHICLE JOURNEY, a new and unique code must be given for it. ExtraJourney should be set to 'true'.</xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 			</xsd:choice>


### PR DESCRIPTION
Removed deprecated notes from documentation in SIRI-ET, based on discussion started in ticket #155