### PR TITLE
add modes to AffectedVehicleJourney

### DIFF
--- a/docs/generated/contab/siri.html
+++ b/docs/generated/contab/siri.html
@@ -207961,6 +207961,55 @@
                   </td>
                   <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
                     <p class="tableblock">
+                      <code>siri:VehicleMode</code>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <span title="optional, multiple">0:*</span>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <em>
+                        <a shape="rect" href="#type.siri:VehicleModesEnumeration" title="siri:VehicleModesEnumeration">siri:VehicleModesEnumeration</a>
+                      </em>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock darkbrown">A means of transportation such as bus, rail, etc.</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <a shape="rect" href="" title=""/>
+                  </td>
+                  <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <code>siri:ProductCategoryRef</code>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <span title="optional, single">0:1</span>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
+                      <em>&gt;<a shape="rect" href="#type.siri:ProductCategoryRefStructure" title="siri:ProductCategoryRefStructure">siri:ProductCategoryRefStructure</a>
+                      </em>
+                    </p>
+                  </td>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock darkbrown">Product Classification of VEHICLE JOURNEY - subdivides a transport mode, e.g. express, local, etc.</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan="1" rowspan="1" class="tableblock halign-left valign-top">
+                    <a shape="rect" href="" title=""/>
+                  </td>
+                  <td colspan="2" rowspan="1" class="tableblock halign-left valign-top">
+                    <p class="tableblock">
                       <code>siri:TrainNumbers</code>
                     </p>
                   </td>

--- a/xsd/siri_model/siri_situationAffects.xsd
+++ b/xsd/siri_model/siri_situationAffects.xsd
@@ -878,7 +878,7 @@ Rail transport, Roads and road transport
 					<xsd:documentation>BLOCK which journey runs. (since SIRI 2.0)</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="VehicleMode" type="VehicleModesEnumeration" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element name="VehicleMode" type="VehicleModesOfTransportEnumeration" minOccurs="0" maxOccurs="unbounded">
 				<xsd:annotation>
 					<xsd:documentation>A means of transportation such as bus, rail, etc.</xsd:documentation>
 				</xsd:annotation>

--- a/xsd/siri_model/siri_situationAffects.xsd
+++ b/xsd/siri_model/siri_situationAffects.xsd
@@ -4,6 +4,8 @@
 	<xsd:include schemaLocation="siri_modes.xsd"/>
 	<xsd:include schemaLocation="siri_situationServiceTypes.xsd"/>
 	<xsd:include schemaLocation="siri_situationClassifiers.xsd"/>
+	<xsd:include schemaLocation="siri_reference.xsd"/>
+	<xsd:include schemaLocation="siri_feature_support.xsd"/>
 	<!-- ======================================================================= -->
 	<!-- Global import of all IFOPT namespace elements used in SIRI needed to work around JAXB/XERCES/xmllint limitations -->
 	<xsd:import namespace="http://www.ifopt.org.uk/ifopt" schemaLocation="../ifopt/ifopt_allStopPlace.xsd"/>
@@ -874,6 +876,16 @@ Rail transport, Roads and road transport
 			<xsd:element name="BlockRef" type="BlockRefStructure" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>BLOCK which journey runs. (since SIRI 2.0)</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="VehicleMode" type="VehicleModesEnumeration" minOccurs="0" maxOccurs="unbounded">
+				<xsd:annotation>
+					<xsd:documentation>A means of transportation such as bus, rail, etc.</xsd:documentation>
+				</xsd:annotation>
+			</xsd:element>
+			<xsd:element name="ProductCategoryRef" type="ProductCategoryRefStructure" minOccurs="0">
+				<xsd:annotation>
+					<xsd:documentation>Product Classification of VEHICLE JOURNEY - subdivides a transport mode, e.g. express, local, etc.</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="TrainNumbers" minOccurs="0">

--- a/xsd/siri_model/siri_situationAffects.xsd
+++ b/xsd/siri_model/siri_situationAffects.xsd
@@ -878,7 +878,7 @@ Rail transport, Roads and road transport
 					<xsd:documentation>BLOCK which journey runs. (since SIRI 2.0)</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
-			<xsd:element name="VehicleMode" type="VehicleModesOfTransportEnumeration" minOccurs="0" maxOccurs="unbounded">
+			<xsd:element name="VehicleMode" type="VehicleModesOfTransportEnumeration" minOccurs="0">
 				<xsd:annotation>
 					<xsd:documentation>A means of transportation such as bus, rail, etc.</xsd:documentation>
 				</xsd:annotation>


### PR DESCRIPTION
Extend AffectedVehicleJourneyStructure of SX with VehicleMode and ProductCategoryRef to harmonize with other services such as PT/ET. Modes are crucial for journey matching (particularly if a global ID standard is not yet established) but also for display of an icon on passenger information systems.