### PR TITLE
Rename perspectives in SX and extend by whilePlanningTrip

### DIFF
--- a/xsd/siri_model/siri_situationActions.xsd
+++ b/xsd/siri_model/siri_situationActions.xsd
@@ -756,9 +756,41 @@ By default, an action does not correspond to a normalisation, i.e., has ActionIs
 			<xsd:documentation>Values for perspectives.</xsd:documentation>
 		</xsd:annotation>
 		<xsd:restriction base="xsd:NMTOKEN">
-			<xsd:enumeration value="general"/>
-			<xsd:enumeration value="stopPoint"/>
-			<xsd:enumeration value="vehicleJourney"/>
+			<xsd:enumeration value="general">
+				<xsd:annotation>
+					<xsd:documentation>DEPRECATED since SIRI 2.3, use anywhere instead</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="stopPoint">
+				<xsd:annotation>
+					<xsd:documentation>DEPRECATED since SIRI 2.3, use atStopPoint instead</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="vehicleJourney">
+				<xsd:annotation>
+					<xsd:documentation>DEPRECATED since SIRI 2.3, use onBoardVehicle instead</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="anywhere">
+				<xsd:annotation>
+					<xsd:documentation>Bird's eye perspective, e.g., passenger looks at an overview of situations on a network map. (since SIRI 2.3)</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="atStopPoint">
+				<xsd:annotation>
+					<xsd:documentation>Passenger looks, for example, at a display on a platform during interchange. (since SIRI 2.3)</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="onBoardVehicle">
+				<xsd:annotation>
+					<xsd:documentation>Passenger looks, for example, at a display while moving in a vehicle. (since SIRI 2.3)</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
+			<xsd:enumeration value="whilePlanningTrip">
+				<xsd:annotation>
+					<xsd:documentation>Passenger looks, for example, at a trip search application on a smartphone. (since SIRI 2.3)</xsd:documentation>
+				</xsd:annotation>
+			</xsd:enumeration>
 		</xsd:restriction>
 	</xsd:simpleType>
 </xsd:schema>

--- a/xsd/siri_model/siri_situationActions.xsd
+++ b/xsd/siri_model/siri_situationActions.xsd
@@ -758,37 +758,37 @@ By default, an action does not correspond to a normalisation, i.e., has ActionIs
 		<xsd:restriction base="xsd:NMTOKEN">
 			<xsd:enumeration value="general">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED since SIRI 2.3, use anywhere instead</xsd:documentation>
+					<xsd:documentation>DEPRECATED since SIRI 2.3, use anywhere instead. -v2.3</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="stopPoint">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED since SIRI 2.3, use atStopPoint instead</xsd:documentation>
+					<xsd:documentation>DEPRECATED since SIRI 2.3, use atStopPoint instead. -v2.3</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="vehicleJourney">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED since SIRI 2.3, use onBoardVehicle instead</xsd:documentation>
+					<xsd:documentation>DEPRECATED since SIRI 2.3, use onBoardVehicle instead. -v.3</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="anywhere">
 				<xsd:annotation>
-					<xsd:documentation>Bird's eye perspective, e.g., passenger looks at an overview of situations on a network map. (since SIRI 2.3)</xsd:documentation>
+					<xsd:documentation>Bird's eye perspective; e.g., passenger looks at an overview of situations on a network map. +v2.3</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="atStopPoint">
 				<xsd:annotation>
-					<xsd:documentation>Passenger looks, for example, at a display on a platform during interchange. (since SIRI 2.3)</xsd:documentation>
+					<xsd:documentation>From the passengers' perpective at a specific stop; e.g., at a display on a platform during interchange. +v2.3</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="onBoardVehicle">
 				<xsd:annotation>
-					<xsd:documentation>Passenger looks, for example, at a display while moving in a vehicle. (since SIRI 2.3)</xsd:documentation>
+					<xsd:documentation>From the passengers' perspective while on board a specific vehicle; e.g., at an onboard display while moving in a vehicle. +v2.3</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="whilePlanningTrip">
 				<xsd:annotation>
-					<xsd:documentation>Passenger looks, for example, at a trip search application on a smartphone. (since SIRI 2.3)</xsd:documentation>
+					<xsd:documentation>From the passengers' perspective while plannig a trip; e.g., while using a trip search application on a smartphone. +v2.3</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 		</xsd:restriction>

--- a/xsd/siri_model/siri_situationActions.xsd
+++ b/xsd/siri_model/siri_situationActions.xsd
@@ -768,7 +768,7 @@ By default, an action does not correspond to a normalisation, i.e., has ActionIs
 			</xsd:enumeration>
 			<xsd:enumeration value="vehicleJourney">
 				<xsd:annotation>
-					<xsd:documentation>DEPRECATED since SIRI 2.3, use onBoardVehicle instead. -v.3</xsd:documentation>
+					<xsd:documentation>DEPRECATED since SIRI 2.3, use onBoardVehicle instead. -v2.3</xsd:documentation>
 				</xsd:annotation>
 			</xsd:enumeration>
 			<xsd:enumeration value="anywhere">


### PR DESCRIPTION
As decided by SG7 in March of 2024, perspectives are "renamed" in the following way:
- stopPoint => atStopPoint
- vehicleJourney => onBoardVehicle
- general => anywhere

and a new perspective 'whilePlanningTrip' is added. The old values are updated with deprecation warning.