### PR TITLE
add missing element StopPlaceName to AffectedStopPlaceStructure in SX

### DIFF
--- a/xsd/siri_model/siri_situationAffects.xsd
+++ b/xsd/siri_model/siri_situationAffects.xsd
@@ -1233,9 +1233,14 @@ Rail transport, Roads and road transport
 							<xsd:documentation>Identifier of STOP PLACE affected by SITUATION.</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
+					<xsd:element name="StopPlaceName" type="NaturalLanguageStringStructure" minOccurs="0" maxOccurs="unbounded">
+						<xsd:annotation>
+							<xsd:documentation>Name of STOP PLACE. (since SIRI 2.3)</xsd:documentation>
+						</xsd:annotation>
+					</xsd:element>
 					<xsd:element name="PlaceName" type="NaturalLanguageStringStructure" minOccurs="0" maxOccurs="unbounded">
 						<xsd:annotation>
-							<xsd:documentation>Name of STOP PLACE.  (Unbounded since SIRI 2.0)</xsd:documentation>
+							<xsd:documentation>Name of PLACE associated with STOP PLACE. (Unbounded since SIRI 2.0)</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
 					<xsd:element name="StopPlaceType" type="StopPlaceTypeEnumeration" minOccurs="0">

--- a/xsd/siri_model/siri_situationAffects.xsd
+++ b/xsd/siri_model/siri_situationAffects.xsd
@@ -1235,7 +1235,7 @@ Rail transport, Roads and road transport
 					</xsd:element>
 					<xsd:element name="StopPlaceName" type="NaturalLanguageStringStructure" minOccurs="0" maxOccurs="unbounded">
 						<xsd:annotation>
-							<xsd:documentation>Name of STOP PLACE. (since SIRI 2.3)</xsd:documentation>
+							<xsd:documentation>Name of STOP PLACE affected by SITUATION. +v2.3</xsd:documentation>
 						</xsd:annotation>
 					</xsd:element>
 					<xsd:element name="PlaceName" type="NaturalLanguageStringStructure" minOccurs="0" maxOccurs="unbounded">


### PR DESCRIPTION
As the title suggests. In AffectedStopPoint there is StopPlaceRef, the corresponding StopPlaceName and also PlaceRef and corresponding PlaceName (in addition to StopPointRef/-Name). However, in AffectedStopPlace there is only PlaceName which generated some confusion on UmS side (VDV736 profile). We propose to add the optional element StopPlaceName (as known in other affects structures) so that there's a cleaner "link" between ref and name.